### PR TITLE
Adds square bracket object lookup syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,10 @@ Values can be looked up in bound json expressions using the standard path lookup
 ```
 {{ $.foo.bar[0]['my key'] }}
 ```
-`.` is used to look up object fields and `[x]` is used to lookup array indices and string literal object fields.
+
+* `.` is used to look up object fields
+* `[x]` is used to lookup array indices
+* `['a b c']` is used to lookup string literal object fields.
 
 #### Loops
 

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Kriti expressions are wrapped in double curly brackets such as `"http://wwww.goo
 
 Values can be looked up in bound json expressions using the standard path lookup syntax:
 ```
-{{ $.foo.bar[0] }}
+{{ $.foo.bar[0]['my key'] }}
 ```
-`.` is used to look up object fields and `[x]` is used to lookup array indices.
+`.` is used to look up object fields and `[x]` is used to lookup array indices and string literal object fields.
 
 #### Loops
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Values can be looked up in bound json expressions using the standard path lookup
 
 * `.` is used to look up object fields
 * `[x]` is used to lookup array indices
-* `['a b c']` is used to lookup string literal object fields.
+* `['a b c']` is used to lookup string literal object fields
 
 #### Loops
 

--- a/kriti-lang.cabal
+++ b/kriti-lang.cabal
@@ -3,7 +3,7 @@ cabal-version:       >=1.10
 --   For further documentation, see http://haskell.org/cabal/users-guide/
 
 name:                kriti-lang
-version:             0.1.0.0
+version:             0.2.0.0
 -- synopsis:
 -- description:
 -- bug-reports:

--- a/src/Kriti/Lexer/Token.hs
+++ b/src/Kriti/Lexer/Token.hs
@@ -38,6 +38,7 @@ class Serialize t where
 data Token
   = -- | String Template
     StringTem T.Text
+  | StringLit T.Text
   | -- | Identifier
     Identifier T.Text
   | -- | Number literal with original string
@@ -66,6 +67,7 @@ data Token
 instance Serialize Token where
   serialize = \case
     StringTem str -> "\"" <> str <> "\""
+    StringLit str -> "\'" <> str <> "\'"
     Identifier iden -> iden
     NumLit str _ -> str
     BoolLit True -> "true"

--- a/src/Kriti/Parser.hs
+++ b/src/Kriti/Parser.hs
@@ -76,8 +76,6 @@ instance J.FromJSON ValueExt where
     J.Object obj | null obj -> pure Null
     J.Object obj -> Object <$> traverse J.parseJSON obj
 
--- {{ range $index, $article := .event.author.articles }}
-
 type Parser = P.Parsec Lex.LexError Lex.TokenStream
 
 match :: (Lex.Token -> Maybe a) -> Parser a
@@ -140,6 +138,11 @@ bool = match \case
 
 stringLit :: Parser Text
 stringLit = match \case
+  Lex.StringLit s -> Just s
+  _ -> Nothing
+
+stringTemSimple :: Parser Text
+stringTemSimple = match \case
   Lex.StringTem s -> Just s
   _ -> Nothing
 
@@ -217,7 +220,7 @@ parseNull = do
   pure Null
 
 parseString :: Parser ValueExt
-parseString = String <$> stringLit
+parseString = String <$> stringTemSimple
 
 parseNumber :: Parser ValueExt
 parseNumber = Number <$> number
@@ -234,7 +237,7 @@ parseObject = do
   where
     parseField :: Parser (Text, ValueExt)
     parseField = do
-      key <- stringLit
+      key <- stringTemSimple
       colon
       value <- parseJson
       pure (key, value)
@@ -251,20 +254,20 @@ parsePath :: Parser ValueExt
 parsePath = do
   startPos <- fromSourcePos <$> P.getSourcePos
   x <- prefix <|> fmap Obj ident
-  xs <- many $ obj <|> arr
+  xs <- many $ dotP <|> bracketP
   let path = ((startPos, x) : xs) & fmap \(pos, el) -> ((pos, Just $ incCol (len el) pos), el)
   pure $ Path path
   where
     len (Obj x) = T.length x
     len (Arr i) = length (show i) + 1
     prefix = P.try $ Obj <$> blingPrefixedId
-    arr = do
+    bracketP = do
       pos <- getSourcePos
       squareOpen
-      x <- Arr <$> integer
+      x <- (Arr <$> integer) <|> (Obj <$> stringLit)
       squareClose
       pure (pos, x)
-    obj = do
+    dotP = do
       pos <- getSourcePos
       dot
       x <- Obj <$> ident

--- a/src/Text/Read/Lex/Extended.hs
+++ b/src/Text/Read/Lex/Extended.hs
@@ -1,4 +1,4 @@
-module Text.Read.Lex.Extended (lexTemplate) where
+module Text.Read.Lex.Extended (lexString, lexTemplate) where
 
 import GHC.Base
 import GHC.Char
@@ -10,6 +10,33 @@ guard :: (MonadPlus m) => Bool -> m ()
 guard True = return ()
 guard False = mzero
 
+lexString :: ReadP Lexeme
+lexString =
+  do
+    quoteChar <- char '\''
+    body id [quoteChar]
+  where
+    body f quoteChar =
+      do
+        (c, esc) <- lexStrItem
+        if c /= quoteChar || esc
+          then body (f . (c <>)) quoteChar
+          else
+            let s = f ""
+             in return (String s)
+
+    lexStrItem =
+      (lexEmpty >> lexStrItem)
+        +++ lexCharE
+
+    lexEmpty =
+      do
+        _ <- char '\\'
+        c <- get
+        case c of
+          '&' -> do return ()
+          _ | isSpace c -> do skipSpaces; _ <- char '\\'; return ()
+          _ -> do pfail
 lexTemplate :: ReadP Lexeme
 lexTemplate =
   do

--- a/src/Text/Read/Lex/Extended.hs
+++ b/src/Text/Read/Lex/Extended.hs
@@ -37,6 +37,7 @@ lexString =
           '&' -> do return ()
           _ | isSpace c -> do skipSpaces; _ <- char '\\'; return ()
           _ -> do pfail
+
 lexTemplate :: ReadP Lexeme
 lexTemplate =
   do

--- a/test/data/parser/success/examples/example14.kriti
+++ b/test/data/parser/success/examples/example14.kriti
@@ -1,1 +1,1 @@
-{ "foo": "x-y", "bar": "a b cde-fgh" }
+{ "foo": "obj['x-y']", "bar": "obj['a b cde-fgh']" }

--- a/test/data/parser/success/examples/example14.kriti
+++ b/test/data/parser/success/examples/example14.kriti
@@ -1,0 +1,1 @@
+{ "foo": "x-y", "bar": "a b cde-fgh" }

--- a/test/data/parser/success/examples/example14.kriti
+++ b/test/data/parser/success/examples/example14.kriti
@@ -1,1 +1,1 @@
-{ "foo": "obj['x-y']", "bar": "obj['a b cde-fgh']" }
+{ "foo": "{{obj['x-y']}}", "bar": "{{obj['a b cde-fgh']}}" }

--- a/test/data/parser/success/golden/example14.txt
+++ b/test/data/parser/success/golden/example14.txt
@@ -1,0 +1,12 @@
+Object
+    ( fromList
+        [
+            ( "bar"
+            , String "a b cde-fgh"
+            )
+        ,
+            ( "foo"
+            , String "x-y"
+            )
+        ]
+    )

--- a/test/data/parser/success/golden/example14.txt
+++ b/test/data/parser/success/golden/example14.txt
@@ -2,11 +2,113 @@ Object
     ( fromList
         [
             ( "bar"
-            , String "obj['a b cde-fgh']"
+            , StringInterp
+                ( SourcePosition
+                    { _sourceName = "sourceName"
+                    , _line = 1
+                    , _column = 35
+                    }
+                , Just
+                    ( SourcePosition
+                        { _sourceName = "sourceName"
+                        , _line = 1
+                        , _column = 60
+                        }
+                    )
+                )
+                [ String ""
+                , Path
+                    [
+                        (
+                            ( SourcePosition
+                                { _sourceName = "sourceName"
+                                , _line = 1
+                                , _column = 1
+                                }
+                            , Just
+                                ( SourcePosition
+                                    { _sourceName = "sourceName"
+                                    , _line = 1
+                                    , _column = 4
+                                    }
+                                )
+                            )
+                        , Obj "obj"
+                        )
+                    ,
+                        (
+                            ( SourcePosition
+                                { _sourceName = "sourceName"
+                                , _line = 1
+                                , _column = 4
+                                }
+                            , Just
+                                ( SourcePosition
+                                    { _sourceName = "sourceName"
+                                    , _line = 1
+                                    , _column = 15
+                                    }
+                                )
+                            )
+                        , Obj "a b cde-fgh"
+                        )
+                    ]
+                ]
             )
         ,
             ( "foo"
-            , String "obj['x-y']"
+            , StringInterp
+                ( SourcePosition
+                    { _sourceName = "sourceName"
+                    , _line = 1
+                    , _column = 10
+                    }
+                , Just
+                    ( SourcePosition
+                        { _sourceName = "sourceName"
+                        , _line = 1
+                        , _column = 26
+                        }
+                    )
+                )
+                [ String ""
+                , Path
+                    [
+                        (
+                            ( SourcePosition
+                                { _sourceName = "sourceName"
+                                , _line = 1
+                                , _column = 1
+                                }
+                            , Just
+                                ( SourcePosition
+                                    { _sourceName = "sourceName"
+                                    , _line = 1
+                                    , _column = 4
+                                    }
+                                )
+                            )
+                        , Obj "obj"
+                        )
+                    ,
+                        (
+                            ( SourcePosition
+                                { _sourceName = "sourceName"
+                                , _line = 1
+                                , _column = 4
+                                }
+                            , Just
+                                ( SourcePosition
+                                    { _sourceName = "sourceName"
+                                    , _line = 1
+                                    , _column = 7
+                                    }
+                                )
+                            )
+                        , Obj "x-y"
+                        )
+                    ]
+                ]
             )
         ]
     )

--- a/test/data/parser/success/golden/example14.txt
+++ b/test/data/parser/success/golden/example14.txt
@@ -2,11 +2,11 @@ Object
     ( fromList
         [
             ( "bar"
-            , String "a b cde-fgh"
+            , String "obj['a b cde-fgh']"
             )
         ,
             ( "foo"
-            , String "x-y"
+            , String "obj['x-y']"
             )
         ]
     )


### PR DESCRIPTION
Adds square bracket style path lookups for Objects:
```
> json' = J.Object $ M.fromList [("test-bar", J.String "baz")]
> runKriti "\"{{$foo['test-bar']}}\"" [("$foo", json')]
Right (String "baz")
```

I think we should consider cleaning up the parser a bit and add golden tests before merging this.