### PR TITLE
Support aeson-2

### DIFF
--- a/kriti-lang.cabal
+++ b/kriti-lang.cabal
@@ -44,7 +44,7 @@ common common-settings
 common common-libraries
   build-depends:
     , base >= 2 && < 5
-    , aeson < 1.6
+    , aeson <1.6 || >=2 && <2.1
     , bytestring
     , containers
     , text
@@ -71,6 +71,7 @@ library
     , vector
   exposed-modules:
     Kriti
+    Kriti.Aeson.Compat
     Kriti.Error
     Kriti.Parser
     Kriti.Parser.Grammar

--- a/src/Kriti/Aeson/Compat.hs
+++ b/src/Kriti/Aeson/Compat.hs
@@ -3,33 +3,31 @@
 module Kriti.Aeson.Compat where
 
 #if MIN_VERSION_aeson(2,0,0)
+
 import qualified Data.Aeson.Key as K
 import qualified Data.Aeson.KeyMap as KM
 import Data.Bifunctor (first)
-#else
-import qualified Data.HashMap.Strict as M
-#endif
 import qualified Data.Text as T
 
-type Object v =
-#if MIN_VERSION_aeson(2,0,0)
-  KM.KeyMap v
-#else
-  M.HashMap T.Text v
-#endif
+type Object v = KM.KeyMap v
 
 fromList :: [(T.Text, v)] -> Object v
-fromList =
-#if MIN_VERSION_aeson(2,0,0)
-  KM.fromList . map (first K.fromText)
-#else
-  M.fromList
-#endif
+fromList = KM.fromList . map (first K.fromText)
 
 lookup :: T.Text -> Object v -> Maybe v
-lookup =
-#if MIN_VERSION_aeson(2,0,0)
-  KM.lookup . K.fromText
+lookup = KM.lookup . K.fromText
+
 #else
-  M.lookup
+
+import qualified Data.HashMap.Strict as M
+import qualified Data.Text as T
+
+type Object v = M.HashMap T.Text v
+
+fromList :: [(T.Text, v)] -> Object v
+fromList = M.fromList
+
+lookup :: T.Text -> Object v -> Maybe v
+lookup = M.lookup
+
 #endif

--- a/src/Kriti/Aeson/Compat.hs
+++ b/src/Kriti/Aeson/Compat.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE CPP #-}
+
+module Kriti.Aeson.Compat where
+
+#if MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson.Key as K
+import qualified Data.Aeson.KeyMap as KM
+import Data.Bifunctor (first)
+#else
+import qualified Data.HashMap.Strict as M
+#endif
+import qualified Data.Text as T
+
+type Object v =
+#if MIN_VERSION_aeson(2,0,0)
+  KM.KeyMap v
+#else
+  M.HashMap T.Text v
+#endif
+
+fromList :: [(T.Text, v)] -> Object v
+fromList =
+#if MIN_VERSION_aeson(2,0,0)
+  KM.fromList . map (first K.fromText)
+#else
+  M.fromList
+#endif
+
+lookup :: T.Text -> Object v -> Maybe v
+lookup =
+#if MIN_VERSION_aeson(2,0,0)
+  KM.lookup . K.fromText
+#else
+  M.lookup
+#endif

--- a/src/Kriti/Parser/Grammar.y
+++ b/src/Kriti/Parser/Grammar.y
@@ -9,6 +9,7 @@ import qualified Data.Scientific as S
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import GHC.Generics
+import qualified Kriti.Aeson.Compat as Compat
 import qualified Kriti.Error as E
 import qualified Kriti.Parser.Lexer as L
 import Kriti.Parser.Monad
@@ -113,7 +114,7 @@ list_elements
 
 object :: { ValueExt }
 object
-: '{' object_fields '}' { Object (locate $1 <> locate $3) (M.fromList $2) }
+: '{' object_fields '}' { Object (locate $1 <> locate $3) (Compat.fromList $2) }
 
 object_fields :: { [(T.Text, ValueExt)] }
 object_fields

--- a/src/Kriti/Parser/Token.hs
+++ b/src/Kriti/Parser/Token.hs
@@ -3,12 +3,12 @@
 
 module Kriti.Parser.Token where
 
-import qualified Data.HashMap.Strict as M
 import qualified Data.List as L
 import Data.Scientific (Scientific)
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import GHC.Generics
+import qualified Kriti.Aeson.Compat as Compat
 import Kriti.Parser.Spans
 
 -- | The type of non literal/identifer symbols extracted from
@@ -109,7 +109,7 @@ renderPath = mconcat . L.intersperse "." . V.toList . fmap renderAccessor
 -- terms.
 data ValueExt
   = -- | Core Aeson Terms
-    Object Span (M.HashMap T.Text ValueExt)
+    Object Span (Compat.Object ValueExt)
   | Array Span (V.Vector ValueExt)
   | String Span T.Text
   | Number Span Scientific

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -13,13 +13,13 @@ import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Lazy.Char8 as BL8
 import Data.Foldable (for_)
-import qualified Data.HashMap.Strict as M
 import Data.Scientific (Scientific)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Encoding (encodeUtf8)
 import qualified Data.Text.Lazy as TL
 import qualified Data.Vector as V
+import qualified Kriti.Aeson.Compat as Compat
 import Kriti.Error
 import Kriti.Eval
 import qualified Kriti.Parser as P
@@ -291,7 +291,7 @@ instance Q.Arbitrary J.Value where
           number' = J.Number <$> Q.arbitrary
           string' = J.String <$> Q.arbitrary
           array' = J.Array . V.fromList <$> Q.arbitrary
-          object' = J.Object . M.fromList <$> Q.arbitrary
+          object' = J.Object . Compat.fromList <$> Q.arbitrary
 
 --------------------------------------------------------------------------------
 -- General test helpers.


### PR DESCRIPTION
This PR adds backwards-compatible support for `aeson-2` via CPP.

The test suite passes on GHC 8.10.7 with both `aeson <1.6` and `aeson >=2 && < 2.1`.