### PR TITLE
Revert "Add build-tool-depends"

### DIFF
--- a/kriti-lang.cabal
+++ b/kriti-lang.cabal
@@ -69,9 +69,6 @@ library
     , scientific
     , unordered-containers
     , vector
-  build-tool-depends:
-    , alex:alex >= 3.2.6
-    , happy:happy >= 1.20
   exposed-modules:
     Kriti
     Kriti.Error


### PR DESCRIPTION
Reverts hasura/kriti-lang#31

I thought this would install `alex` and `happy` when trying to build `graphql-engine` in CI, but it turn out it doesn't.