### PR TITLE
Fixes span generation for functions

### DIFF
--- a/src/Kriti/Parser/Grammar.y
+++ b/src/Kriti/Parser/Grammar.y
@@ -143,7 +143,7 @@ function_call
 
 functions :: { ValueExt -> ValueExt }
 functions
-  : 'escapeUri' { EscapeURI (locate $1) }
+  : 'escapeUri' { function EscapeURI (locate $1) }
 
 function_params :: { ValueExt }
 function_params
@@ -188,12 +188,13 @@ path_element
 
 value :: { ValueExt }
 value
-  : path_vector { uncurry Path $1 }
+  : num_lit { $1}
+  | string_lit { $1 }
+  | boolean  { $1 }
+  | null { $1 }
+  | path_vector { uncurry Path $1 }
   | iff { $1 }
   | operator { $1 }
-  | boolean  { $1 }
-  | num_lit { $1}
-  | string_lit { $1 }
   | '(' value ')' { $2 }
 
 term :: { ValueExt }
@@ -208,7 +209,7 @@ term
   | iff           { $1 }
   | function_call { $1 }
   | range         { $1 }
-  | '(' term ')' { $2 }
+  | '(' term ')'  { $2 }
 
 {
 failure :: [Token] -> Parser a

--- a/src/Kriti/Parser/Monad.hs
+++ b/src/Kriti/Parser/Monad.hs
@@ -144,6 +144,9 @@ symbol sym _ = do
   sp <- location
   pure $ TokSymbol $ Loc sp sym
 
+function :: (Span -> ValueExt -> ValueExt) -> Span -> ValueExt -> ValueExt
+function f sp param = f (sp <> locate param) param
+
 -----------------------
 --- Alex Primitives ---
 -----------------------

--- a/test/data/parser/success/golden/functions.txt
+++ b/test/data/parser/success/golden/functions.txt
@@ -18,7 +18,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 1
-                , col = 15
+                , col = 21
                 }
             }
         )
@@ -56,7 +56,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 2
-                , col = 15
+                , col = 29
                 }
             }
         )
@@ -119,7 +119,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 3
-                , col = 15
+                , col = 24
                 }
             }
         )
@@ -169,7 +169,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 4
-                , col = 15
+                , col = 30
                 }
             }
         )
@@ -231,7 +231,7 @@ Array
                     }
                 , end = AlexSourcePos
                     { line = 5
-                    , col = 36
+                    , col = 44
                     }
                 }
             )


### PR DESCRIPTION
There is a bug in span generation for functions at the moment:
```
> parser "{{ escapeUri \"foo\" }}"
Right (EscapeURI (Span {start = AlexSourcePos {line = 0, col = 4}, end = AlexSourcePos {line = 0, col = 13}}) (StringTem (Span {start = AlexSourcePos {line = 0, col = 14}, end = AlexSourcePos {line = 0, col = 19}}) [String (Span {start = AlexSourcePos {line = 0, col = 15}, end = AlexSourcePos {line = 0, col = 18}}) "foo"]))
```
Notice how the `EscapeURI` span ends on column 13. It should include the contained `StringTem`.

This PR fixes the issue:
```
> parser "{{ escapeUri \"foo\" }}"
Right (EscapeURI (Span {start = AlexSourcePos {line = 0, col = 4}, end = AlexSourcePos {line = 0, col = 19}}) (StringTem (Span {start = AlexSourcePos {line = 0, col = 14}, end = AlexSourcePos {line = 0, col = 19}}) [String (Span {start = AlexSourcePos {line = 0, col = 15}, end = AlexSourcePos {line = 0, col = 18}}) "foo"]))
```