### PR TITLE
Fix unicode handling in lexer

### DIFF
--- a/kriti-lang.cabal
+++ b/kriti-lang.cabal
@@ -26,6 +26,7 @@ common common-settings
     LambdaCase
     NamedFieldPuns
     OverloadedStrings
+    StrictData
     RecordWildCards
     TupleSections
     DerivingVia

--- a/src/Kriti/Parser/Grammar.y
+++ b/src/Kriti/Parser/Grammar.y
@@ -1,4 +1,6 @@
 {
+-- We have to disable -XStrictData here, as it doesn't play nicely with Happy.
+{-# LANGUAGE NoStrictData #-}
 module Kriti.Parser.Grammar where
 
 import Control.Monad.State (gets)

--- a/src/Kriti/Parser/Lexer.x
+++ b/src/Kriti/Parser/Lexer.x
@@ -10,8 +10,8 @@ import Kriti.Parser.Token
 
 $digit = 0-9
 $alpha = [a-zA-Z]
-$alphanum = [a-zA-Z09]
-$hex = [A-F09]
+$alphanum = [a-zA-Z0-9]
+$hex = [A-Fa-f0-9]
 
 tokens :-
 

--- a/src/Kriti/Parser/Monad.hs
+++ b/src/Kriti/Parser/Monad.hs
@@ -18,9 +18,9 @@ import Prettyprinter hiding (line)
 
 data ParserState = ParserState
   { parseSource :: B.ByteString,
-    parseInput :: {-# UNPACK #-} !AlexInput,
-    parseStartCodes :: {-# UNPACK #-} !(NE.NonEmpty Int),
-    parseSpan :: !Span
+    parseInput :: {-# UNPACK #-} AlexInput,
+    parseStartCodes :: {-# UNPACK #-} (NE.NonEmpty Int),
+    parseSpan :: Span
   }
 
 initState :: [Int] -> B.ByteString -> ParserState
@@ -162,7 +162,7 @@ textToken k txt _ = k <$> located txt
 -- | Construct a Token from the matched Text and the current `parseSpan`.
 {-# INLINE token #-}
 token :: (Loc T.Text -> Token) -> B.ByteString -> Parser Token
-token k bs = k <$> located (TE.decodeLatin1 bs)
+token k bs = k <$> located (TE.decodeUtf8 bs)
 
 -- | Construct a `(TokenSymbol (Loc _))` using the current `parseSpan`
 -- to construct the `Loc _`.
@@ -244,4 +244,4 @@ alexPrevInputChar = lexPrevChar
 
 {-# INLINE slice #-}
 slice :: Int -> AlexInput -> B.ByteString
-slice n AlexInput {..} = B.take n lexBytes
+slice n AlexInput {..} = UTFBS.take n lexBytes


### PR DESCRIPTION
## Patch Description

This PR fixes a couple of bugs related to lexing unicode characters.
The first is that the regexes for lexing hex literals wasn't correct. This caused
issues when we tried to lex escaped unicode chars like `\u00c1`.

The second bug was a bit trickier to track down. We noticed that evaluating expressions that contained codepoints above U+007F caused crashes. However, this was somewhat of a red herring; the evaluation was only forcing exceptions that were created in the lexer.

In particular, the following function was throwing due to an invalid sequence of unicode bytes:
```haskell
token :: (Loc T.Text -> Token) -> B.ByteString -> Parser Token
token k bs = k <$> located (TE.decodeUtf8 bs)
```

The reason this was throwing was a somewhat silly mistake: we used the wrong `BS.take` in `slice`!
```haskell
slice :: Int -> AlexInput -> B.ByteString
slice n AlexInput {..} = B.take n lexBytes
```

Note that this takes n _bytes_, not n _characters_. Luckily, this is easily fixed by using `Data.ByteString.UTF8.take`.

## Notes

This PR also enables [-XStrictData](https://ghc.gitlab.haskell.org/ghc/doc/users_guide/exts/strict.html#strict-by-default-data-types) by default. This is almost always the correct choice IMO, as it means we don't need to litter our code with `!` to get the behaviour that we almost always want.