### PR TITLE
kriti: add support for custom function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /dist-newstyle/
 /.envrc
 cabal.project.local
+.vscode/

--- a/examples/Example.hs
+++ b/examples/Example.hs
@@ -3,36 +3,72 @@
 
 module Main where
 
+import Control.Monad.Except
 import qualified Data.Aeson as J
+import qualified Data.Aeson.Key as K
+import qualified Data.Aeson.KeyMap as K
+import Data.Bifunctor (first)
 import qualified Data.ByteString.Lazy as BL
 import Data.Maybe
 import Data.Text (Text)
-import Kriti (runKriti)
+import qualified Data.Text as T
+import Kriti (renderPretty, runKritiWith)
+import Kriti.Eval (EvalError (CustomError))
 import Network.HTTP.Client
+import Network.HTTP.Client.TLS
+import Prettyprinter
 import Text.RawString.QQ
 
 exampleTemplate :: Text
 exampleTemplate =
   [r|
-{
-   'id': {{$.id}},
-   'name': {{$.name.english}},
-   'description': {{$.description}},
-   'profile': {
-       'height': {{$.profile.height}},
-       'weight': {{$.profile.weight}},
-       'hp': {{$.base.HP}},
-       'attack': {{$.base.Attack}},
-       'defence': {{$.base.Defense}},
-       'speed': {{$.base.Speed}}
-   }
-}
+{{ range i, x := $.results }}
+  {
+    "id" : {{i}},
+    "fullName" : {{concatName x.name}},
+    "profile" : {
+      "gender" : {{getG x.gender}},
+      "emailID": {{x.email}},
+      "isSuperUser" : {{isAdmin x.login.username}}
+    }
+  }
+{{ end }}
+
 |]
 
 main :: IO ()
 main = do
-  manager <- newManager defaultManagerSettings
-  request <- parseRequest "http://app.pokemon-api.xyz/pokemon/pikachu"
+  manager <- newManager tlsManagerSettings
+  request <- parseRequest "https://randomuser.me/api/?results=10"
   response <- httpLbs request manager
   let parseResp = fromJust . J.decode $ responseBody response
-  print $ runKriti exampleTemplate [("$", parseResp)]
+
+      getNameUnsafe :: J.Object -> Text
+      getNameUnsafe obj = T.intercalate " " $ map (`lk` obj) ["title", "first", "last"]
+        where
+          lk t ob = case K.lookup (K.fromText t) ob of
+            Just (J.String txt) -> txt
+            _ -> error . T.unpack $ t <> " not found"
+
+      mkName :: J.Value -> Either EvalError J.Value
+      mkName inp = case inp of
+        J.Object km -> Right . J.String $ getNameUnsafe km
+        _ -> Left $ CustomError "expected an object in name"
+
+      getGender :: J.Value -> Either EvalError J.Value
+      getGender inp = case inp of
+        J.String txt -> Right . J.String . T.singleton . T.head . T.toUpper $ txt
+        _ -> Left $ CustomError "expected gender to be a string"
+
+      isAdmin :: J.Value -> Either EvalError J.Value
+      isAdmin inp = case inp of
+        J.String txt -> Right . J.Bool $ txt == "admin"
+        _ -> Left $ CustomError "expected usename to be a string"
+
+      functionList = [("concatName", mkName), ("getG", getGender), ("isAdmin", isAdmin)]
+
+  either
+    (print . pretty)
+    (print . J.encode)
+    $ first renderPretty $
+      runKritiWith exampleTemplate [("$", parseResp)] functionList

--- a/examples/Example.hs
+++ b/examples/Example.hs
@@ -13,7 +13,7 @@ import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as T
 import Kriti (renderPretty, runKritiWith)
-import Kriti.Eval (EvalError (CustomError))
+import Kriti.Error (CustomFunctionError (..))
 import Network.HTTP.Client
 import Network.HTTP.Client.TLS
 import Prettyprinter
@@ -50,20 +50,20 @@ main = do
             Just (J.String txt) -> txt
             _ -> error . T.unpack $ t <> " not found"
 
-      mkName :: J.Value -> Either EvalError J.Value
+      mkName :: J.Value -> Either CustomFunctionError J.Value
       mkName inp = case inp of
         J.Object km -> Right . J.String $ getNameUnsafe km
-        _ -> Left $ CustomError "expected an object in name"
+        _ -> Left $ CustomFunctionError "expected an object in name"
 
-      getGender :: J.Value -> Either EvalError J.Value
+      getGender :: J.Value -> Either CustomFunctionError J.Value
       getGender inp = case inp of
         J.String txt -> Right . J.String . T.singleton . T.head . T.toUpper $ txt
-        _ -> Left $ CustomError "expected gender to be a string"
+        _ -> Left $ CustomFunctionError "expected gender to be a string"
 
-      isAdmin :: J.Value -> Either EvalError J.Value
+      isAdmin :: J.Value -> Either CustomFunctionError J.Value
       isAdmin inp = case inp of
         J.String txt -> Right . J.Bool $ txt == "admin"
-        _ -> Left $ CustomError "expected usename to be a string"
+        _ -> Left $ CustomFunctionError "expected usename to be a string"
 
       functionList = [("concatName", mkName), ("getG", getGender), ("isAdmin", isAdmin)]
 

--- a/examples/Example.hs
+++ b/examples/Example.hs
@@ -3,12 +3,10 @@
 
 module Main where
 
-import Control.Monad.Except
 import qualified Data.Aeson as J
 import qualified Data.Aeson.Key as K
 import qualified Data.Aeson.KeyMap as K
 import Data.Bifunctor (first)
-import qualified Data.ByteString.Lazy as BL
 import Data.Maybe
 import Data.Text (Text)
 import qualified Data.Text as T

--- a/examples/source.json
+++ b/examples/source.json
@@ -1,0 +1,570 @@
+{
+    "results": [
+        {
+            "gender": "male",
+            "name": {
+                "title": "Monsieur",
+                "first": "Ismail",
+                "last": "Legrand"
+            },
+            "location": {
+                "street": {
+                    "number": 9472,
+                    "name": "Place de L'Abbé-Basset"
+                },
+                "city": "Wittenbach",
+                "state": "Vaud",
+                "country": "Switzerland",
+                "postcode": 9579,
+                "coordinates": {
+                    "latitude": "-55.7133",
+                    "longitude": "-18.5342"
+                },
+                "timezone": {
+                    "offset": "-8:00",
+                    "description": "Pacific Time (US & Canada)"
+                }
+            },
+            "email": "ismail.legrand@example.com",
+            "login": {
+                "uuid": "682f3fe9-3c24-473c-9096-9812fe8f19e8",
+                "username": "purplegorilla623",
+                "password": "505050",
+                "salt": "mVlsDoWu",
+                "md5": "e75c230af6b63606ed7e181e7547d765",
+                "sha1": "581086f90512bb0c1f4d2ec29057f4dc841798a8",
+                "sha256": "53f6682097dbd613549055faeac6aed07f2837accae91778cd2e7f82b379b55a"
+            },
+            "dob": {
+                "date": "1971-10-01T07:15:33.273Z",
+                "age": 51
+            },
+            "registered": {
+                "date": "2003-11-06T07:12:16.616Z",
+                "age": 19
+            },
+            "phone": "079 591 68 57",
+            "cell": "078 055 89 16",
+            "id": {
+                "name": "AVS",
+                "value": "756.7218.6075.55"
+            },
+            "picture": {
+                "large": "https://randomuser.me/api/portraits/men/15.jpg",
+                "medium": "https://randomuser.me/api/portraits/med/men/15.jpg",
+                "thumbnail": "https://randomuser.me/api/portraits/thumb/men/15.jpg"
+            },
+            "nat": "CH"
+        },
+        {
+            "gender": "male",
+            "name": {
+                "title": "Mr",
+                "first": "Oscar",
+                "last": "Matthews"
+            },
+            "location": {
+                "street": {
+                    "number": 3442,
+                    "name": "O'Connell Street"
+                },
+                "city": "Skerries",
+                "state": "Carlow",
+                "country": "Ireland",
+                "postcode": 50356,
+                "coordinates": {
+                    "latitude": "45.8945",
+                    "longitude": "67.6641"
+                },
+                "timezone": {
+                    "offset": "-2:00",
+                    "description": "Mid-Atlantic"
+                }
+            },
+            "email": "oscar.matthews@example.com",
+            "login": {
+                "uuid": "088df39b-33db-40b9-8895-c9558d0790e6",
+                "username": "crazyfrog564",
+                "password": "thebear",
+                "salt": "Lc5AkYP9",
+                "md5": "d3fb45ec755d409ad97a85385e6870f8",
+                "sha1": "6200e74cf13cdba148d274bdee57278a32850e72",
+                "sha256": "e06b6ee9ef59fa78909270a8e3b24afadb62b24a4c9a7a222943f4e73c9a948c"
+            },
+            "dob": {
+                "date": "1981-08-10T05:14:08.051Z",
+                "age": 41
+            },
+            "registered": {
+                "date": "2016-03-19T04:18:47.513Z",
+                "age": 6
+            },
+            "phone": "031-502-7341",
+            "cell": "081-977-1104",
+            "id": {
+                "name": "PPS",
+                "value": "6464851T"
+            },
+            "picture": {
+                "large": "https://randomuser.me/api/portraits/men/37.jpg",
+                "medium": "https://randomuser.me/api/portraits/med/men/37.jpg",
+                "thumbnail": "https://randomuser.me/api/portraits/thumb/men/37.jpg"
+            },
+            "nat": "IE"
+        },
+        {
+            "gender": "female",
+            "name": {
+                "title": "Mrs",
+                "first": "Wanda",
+                "last": "May"
+            },
+            "location": {
+                "street": {
+                    "number": 3538,
+                    "name": "W Sherman Dr"
+                },
+                "city": "Hobart",
+                "state": "South Australia",
+                "country": "Australia",
+                "postcode": 487,
+                "coordinates": {
+                    "latitude": "-60.7682",
+                    "longitude": "114.4906"
+                },
+                "timezone": {
+                    "offset": "+6:00",
+                    "description": "Almaty, Dhaka, Colombo"
+                }
+            },
+            "email": "wanda.may@example.com",
+            "login": {
+                "uuid": "afe458ac-5581-43c5-b2ec-c1206a797e92",
+                "username": "redrabbit369",
+                "password": "gong",
+                "salt": "PLg1GnDf",
+                "md5": "dcb3e35909321f9c98c82699c613a7e3",
+                "sha1": "200f7c4e8a82da0d1b87839fbbd74246805d873c",
+                "sha256": "6aec7bb5c2a5fa4b89be2287f20c96525c0c034948a0b688e69ec01eb5554f9f"
+            },
+            "dob": {
+                "date": "1972-03-09T07:34:41.496Z",
+                "age": 50
+            },
+            "registered": {
+                "date": "2006-09-09T07:33:12.570Z",
+                "age": 16
+            },
+            "phone": "07-9596-6478",
+            "cell": "0481-981-227",
+            "id": {
+                "name": "TFN",
+                "value": "269080991"
+            },
+            "picture": {
+                "large": "https://randomuser.me/api/portraits/women/13.jpg",
+                "medium": "https://randomuser.me/api/portraits/med/women/13.jpg",
+                "thumbnail": "https://randomuser.me/api/portraits/thumb/women/13.jpg"
+            },
+            "nat": "AU"
+        },
+        {
+            "gender": "female",
+            "name": {
+                "title": "Ms",
+                "first": "Purificacion",
+                "last": "Marin"
+            },
+            "location": {
+                "street": {
+                    "number": 7647,
+                    "name": "Calle de Ferraz"
+                },
+                "city": "Logroño",
+                "state": "Aragón",
+                "country": "Spain",
+                "postcode": 70433,
+                "coordinates": {
+                    "latitude": "-89.2094",
+                    "longitude": "62.4190"
+                },
+                "timezone": {
+                    "offset": "+4:30",
+                    "description": "Kabul"
+                }
+            },
+            "email": "purificacion.marin@example.com",
+            "login": {
+                "uuid": "f97c5e78-aa91-4d83-b16b-c4842cf9fb96",
+                "username": "whitefrog648",
+                "password": "cubbies",
+                "salt": "dNRctGpL",
+                "md5": "b661f7a2c5d523b378c0643e4e9c1df4",
+                "sha1": "a82977ea136725c1c3d415074687d940efa31da7",
+                "sha256": "b9fbc190f852e4442e5333d803ac015fe8fa25c2ef83436e5aa3f389c6270701"
+            },
+            "dob": {
+                "date": "1979-07-07T09:04:10.595Z",
+                "age": 43
+            },
+            "registered": {
+                "date": "2015-10-13T13:01:40.240Z",
+                "age": 7
+            },
+            "phone": "903-242-782",
+            "cell": "676-493-534",
+            "id": {
+                "name": "DNI",
+                "value": "62746413-L"
+            },
+            "picture": {
+                "large": "https://randomuser.me/api/portraits/women/36.jpg",
+                "medium": "https://randomuser.me/api/portraits/med/women/36.jpg",
+                "thumbnail": "https://randomuser.me/api/portraits/thumb/women/36.jpg"
+            },
+            "nat": "ES"
+        },
+        {
+            "gender": "male",
+            "name": {
+                "title": "Mr",
+                "first": "Kirk",
+                "last": "Olson"
+            },
+            "location": {
+                "street": {
+                    "number": 241,
+                    "name": "Wycliff Ave"
+                },
+                "city": "Springfield",
+                "state": "Alabama",
+                "country": "United States",
+                "postcode": 50819,
+                "coordinates": {
+                    "latitude": "36.0409",
+                    "longitude": "136.5402"
+                },
+                "timezone": {
+                    "offset": "-9:00",
+                    "description": "Alaska"
+                }
+            },
+            "email": "kirk.olson@example.com",
+            "login": {
+                "uuid": "d2ee244c-4ae0-4d1e-a306-dc8cac771a0a",
+                "username": "smallkoala732",
+                "password": "horndog",
+                "salt": "zgwoSq5O",
+                "md5": "7ec46e65399ef31cc9614c053548c626",
+                "sha1": "60f73ecd2272d678bdbfed00e00e251c9622c86d",
+                "sha256": "ca63940130475000dc69fa0617e25d3a5dc36b8c47101e3a5fe08d01bd1dc28a"
+            },
+            "dob": {
+                "date": "1958-10-19T01:27:00.646Z",
+                "age": 64
+            },
+            "registered": {
+                "date": "2003-09-04T08:38:41.529Z",
+                "age": 19
+            },
+            "phone": "(664)-136-2741",
+            "cell": "(806)-244-1099",
+            "id": {
+                "name": "SSN",
+                "value": "593-30-9926"
+            },
+            "picture": {
+                "large": "https://randomuser.me/api/portraits/men/28.jpg",
+                "medium": "https://randomuser.me/api/portraits/med/men/28.jpg",
+                "thumbnail": "https://randomuser.me/api/portraits/thumb/men/28.jpg"
+            },
+            "nat": "US"
+        },
+        {
+            "gender": "female",
+            "name": {
+                "title": "Miss",
+                "first": "Kate",
+                "last": "Smith"
+            },
+            "location": {
+                "street": {
+                    "number": 4793,
+                    "name": "Domain Road"
+                },
+                "city": "Hamilton",
+                "state": "Auckland",
+                "country": "New Zealand",
+                "postcode": 34333,
+                "coordinates": {
+                    "latitude": "37.1121",
+                    "longitude": "-162.6249"
+                },
+                "timezone": {
+                    "offset": "0:00",
+                    "description": "Western Europe Time, London, Lisbon, Casablanca"
+                }
+            },
+            "email": "kate.smith@example.com",
+            "login": {
+                "uuid": "48494e59-ac50-4537-8bd3-ca6e5966a4c7",
+                "username": "yellowfish795",
+                "password": "pharmacy",
+                "salt": "sAWL7u0p",
+                "md5": "2cae254c539b715522db704477352b04",
+                "sha1": "194490d8ec0e9b07634ef14f538013d510918cf2",
+                "sha256": "a24ab5bc93114661e202fd79ea673fc17d3261e629a155733b3435c6f0ca503a"
+            },
+            "dob": {
+                "date": "1959-03-06T00:16:14.491Z",
+                "age": 63
+            },
+            "registered": {
+                "date": "2010-08-20T14:09:29.582Z",
+                "age": 12
+            },
+            "phone": "(048)-665-2504",
+            "cell": "(138)-529-8421",
+            "id": {
+                "name": "",
+                "value": null
+            },
+            "picture": {
+                "large": "https://randomuser.me/api/portraits/women/63.jpg",
+                "medium": "https://randomuser.me/api/portraits/med/women/63.jpg",
+                "thumbnail": "https://randomuser.me/api/portraits/thumb/women/63.jpg"
+            },
+            "nat": "NZ"
+        },
+        {
+            "gender": "female",
+            "name": {
+                "title": "Miss",
+                "first": "Mary",
+                "last": "Bock"
+            },
+            "location": {
+                "street": {
+                    "number": 3814,
+                    "name": "Schützenstraße"
+                },
+                "city": "Bad Schandau",
+                "state": "Bremen",
+                "country": "Germany",
+                "postcode": 32107,
+                "coordinates": {
+                    "latitude": "26.1727",
+                    "longitude": "-11.0142"
+                },
+                "timezone": {
+                    "offset": "-4:00",
+                    "description": "Atlantic Time (Canada), Caracas, La Paz"
+                }
+            },
+            "email": "mary.bock@example.com",
+            "login": {
+                "uuid": "157f39a2-0fd0-4761-93b4-ea7d7b414ab7",
+                "username": "bigladybug222",
+                "password": "peachy",
+                "salt": "ehu65qFv",
+                "md5": "5d1509892a7ac7e8739111100d9f8a4a",
+                "sha1": "18d8f9c55c2a588f7fbaa14168a74b31380a18e5",
+                "sha256": "b1c25a7a82682644c0564e09cf27693306dff06ee2408ee9fae7c43b41d14f21"
+            },
+            "dob": {
+                "date": "1981-07-02T01:39:15.739Z",
+                "age": 41
+            },
+            "registered": {
+                "date": "2006-01-02T05:46:10.475Z",
+                "age": 16
+            },
+            "phone": "0278-7157728",
+            "cell": "0177-7607990",
+            "id": {
+                "name": "",
+                "value": null
+            },
+            "picture": {
+                "large": "https://randomuser.me/api/portraits/women/41.jpg",
+                "medium": "https://randomuser.me/api/portraits/med/women/41.jpg",
+                "thumbnail": "https://randomuser.me/api/portraits/thumb/women/41.jpg"
+            },
+            "nat": "DE"
+        },
+        {
+            "gender": "female",
+            "name": {
+                "title": "Mrs",
+                "first": "Sophie",
+                "last": "Tucker"
+            },
+            "location": {
+                "street": {
+                    "number": 9480,
+                    "name": "Church Road"
+                },
+                "city": "Manchester",
+                "state": "Gwent",
+                "country": "United Kingdom",
+                "postcode": "MF2B 6SE",
+                "coordinates": {
+                    "latitude": "-57.6607",
+                    "longitude": "-50.4930"
+                },
+                "timezone": {
+                    "offset": "-11:00",
+                    "description": "Midway Island, Samoa"
+                }
+            },
+            "email": "sophie.tucker@example.com",
+            "login": {
+                "uuid": "a3c62d0a-3773-40ef-8f54-0ef3add8a477",
+                "username": "biggoose792",
+                "password": "pizza1",
+                "salt": "adOxqD1C",
+                "md5": "53176cd453ca7a73c9c1a9f91bc52481",
+                "sha1": "cda68c1a92552fa81a88a4c54d0b6d2f56ef3837",
+                "sha256": "2d38fbeb79b4f371f3968ad95aaade213a2f93eabd94256c3bb15540cb004065"
+            },
+            "dob": {
+                "date": "1959-12-31T12:56:28.882Z",
+                "age": 63
+            },
+            "registered": {
+                "date": "2018-08-15T05:36:39.436Z",
+                "age": 4
+            },
+            "phone": "013873 53181",
+            "cell": "0709-457-258",
+            "id": {
+                "name": "NINO",
+                "value": "BT 36 58 04 H"
+            },
+            "picture": {
+                "large": "https://randomuser.me/api/portraits/women/10.jpg",
+                "medium": "https://randomuser.me/api/portraits/med/women/10.jpg",
+                "thumbnail": "https://randomuser.me/api/portraits/thumb/women/10.jpg"
+            },
+            "nat": "GB"
+        },
+        {
+            "gender": "male",
+            "name": {
+                "title": "Mr",
+                "first": "Harro",
+                "last": "Barendsen"
+            },
+            "location": {
+                "street": {
+                    "number": 7721,
+                    "name": "Beelenlaan"
+                },
+                "city": "Ammerzoden",
+                "state": "Utrecht",
+                "country": "Netherlands",
+                "postcode": 70442,
+                "coordinates": {
+                    "latitude": "-52.5901",
+                    "longitude": "-79.2081"
+                },
+                "timezone": {
+                    "offset": "-11:00",
+                    "description": "Midway Island, Samoa"
+                }
+            },
+            "email": "harro.barendsen@example.com",
+            "login": {
+                "uuid": "0446c9f5-f3af-44c4-ba17-d9a9480626e8",
+                "username": "sadgorilla287",
+                "password": "bertha",
+                "salt": "1lI1m4pa",
+                "md5": "6ab4ac866e49b859322e00c20b1fcfdf",
+                "sha1": "b62225df6b9496c6424f6e294e49327f91a53779",
+                "sha256": "7ca5c777893066495c2cd019d006ce3de6d5248c4b01f90cc6f076ad02f33bfc"
+            },
+            "dob": {
+                "date": "1968-03-22T08:43:57.479Z",
+                "age": 54
+            },
+            "registered": {
+                "date": "2003-03-19T15:33:18.497Z",
+                "age": 19
+            },
+            "phone": "(269)-712-8478",
+            "cell": "(105)-335-3369",
+            "id": {
+                "name": "BSN",
+                "value": "58189701"
+            },
+            "picture": {
+                "large": "https://randomuser.me/api/portraits/men/90.jpg",
+                "medium": "https://randomuser.me/api/portraits/med/men/90.jpg",
+                "thumbnail": "https://randomuser.me/api/portraits/thumb/men/90.jpg"
+            },
+            "nat": "NL"
+        },
+        {
+            "gender": "female",
+            "name": {
+                "title": "Miss",
+                "first": "Zulma",
+                "last": "Gonçalves"
+            },
+            "location": {
+                "street": {
+                    "number": 5888,
+                    "name": "Rua Duque de Caxias "
+                },
+                "city": "Caucaia",
+                "state": "Espírito Santo",
+                "country": "Brazil",
+                "postcode": 56060,
+                "coordinates": {
+                    "latitude": "-48.7056",
+                    "longitude": "156.3111"
+                },
+                "timezone": {
+                    "offset": "+8:00",
+                    "description": "Beijing, Perth, Singapore, Hong Kong"
+                }
+            },
+            "email": "zulma.goncalves@example.com",
+            "login": {
+                "uuid": "e7323db0-046e-4143-915e-e485a172a364",
+                "username": "organicpanda236",
+                "password": "casper",
+                "salt": "ZydJxv8S",
+                "md5": "1bae8b9e7dd1b60ce937152d0b00f247",
+                "sha1": "2fcb00ecb3f81485f1bcdd490e53f08e8e3b05ba",
+                "sha256": "05194b8634a97a50d918cce903ddf8436a19e66a68e53d32c5228bbeb27c50cf"
+            },
+            "dob": {
+                "date": "1950-02-27T10:22:37.174Z",
+                "age": 72
+            },
+            "registered": {
+                "date": "2019-06-10T20:34:02.173Z",
+                "age": 3
+            },
+            "phone": "(58) 1450-2551",
+            "cell": "(56) 6380-0574",
+            "id": {
+                "name": "",
+                "value": null
+            },
+            "picture": {
+                "large": "https://randomuser.me/api/portraits/women/89.jpg",
+                "medium": "https://randomuser.me/api/portraits/med/women/89.jpg",
+                "thumbnail": "https://randomuser.me/api/portraits/thumb/women/89.jpg"
+            },
+            "nat": "BR"
+        }
+    ],
+    "info": {
+        "seed": "8227c5cecde7f232",
+        "results": 10,
+        "page": 1,
+        "version": "1.3"
+    }
+}

--- a/kriti-lang.cabal
+++ b/kriti-lang.cabal
@@ -85,6 +85,7 @@ library
     Kriti.Parser.Spans
     Kriti.Parser.Token
     Kriti.Eval
+    Kriti.CustomFunctions
   other-modules:
     Paths_kriti_lang
 

--- a/src/Kriti.hs
+++ b/src/Kriti.hs
@@ -39,11 +39,11 @@ runKriti templateSrc source = do
   template' <- first KritiParseError $ parser templateSrc'
   first KritiEvalError $ runEval templateSrc' template' source
 
-runKritiWith :: T.Text -> [(T.Text, J.Value)] -> (T.Text, J.Value  -> J.Value) -> Either KritiError J.Value
-runKritiWith templateSrc source func = do
+runKritiWith :: T.Text -> [(T.Text, J.Value)] -> [(T.Text, J.Value  -> Either EvalError J.Value)] -> Either KritiError J.Value
+runKritiWith templateSrc source funcLst = do
   let templateSrc' = T.encodeUtf8 templateSrc
   template' <- first KritiParseError $ parser templateSrc'
-  first KritiEvalError $ runEvalWith templateSrc' template' source func
+  first KritiEvalError $ runEvalWith templateSrc' template' source funcLst
 
 -- | Entry point for Kriti when given a template as
 -- 'ByteString'. Caller must ensure that the input is valid UTF8

--- a/src/Kriti.hs
+++ b/src/Kriti.hs
@@ -6,6 +6,7 @@ module Kriti
     renderPretty,
     runKriti,
     runKritiBS,
+    runKritiWith,
   )
 where
 
@@ -37,6 +38,12 @@ runKriti templateSrc source = do
   let templateSrc' = T.encodeUtf8 templateSrc
   template' <- first KritiParseError $ parser templateSrc'
   first KritiEvalError $ runEval templateSrc' template' source
+
+runKritiWith :: T.Text -> [(T.Text, J.Value)] -> (T.Text, J.Value  -> J.Value) -> Either KritiError J.Value
+runKritiWith templateSrc source func = do
+  let templateSrc' = T.encodeUtf8 templateSrc
+  template' <- first KritiParseError $ parser templateSrc'
+  first KritiEvalError $ runEvalWith templateSrc' template' source func
 
 -- | Entry point for Kriti when given a template as
 -- 'ByteString'. Caller must ensure that the input is valid UTF8

--- a/src/Kriti.hs
+++ b/src/Kriti.hs
@@ -39,7 +39,7 @@ runKriti templateSrc source = do
   template' <- first KritiParseError $ parser templateSrc'
   first KritiEvalError $ runEval templateSrc' template' source
 
-runKritiWith :: T.Text -> [(T.Text, J.Value)] -> [(T.Text, J.Value -> Either EvalError J.Value)] -> Either KritiError J.Value
+runKritiWith :: T.Text -> [(T.Text, J.Value)] -> [(T.Text, J.Value -> Either CustomFunctionError J.Value)] -> Either KritiError J.Value
 runKritiWith templateSrc source funcLst = do
   let templateSrc' = T.encodeUtf8 templateSrc
   template' <- first KritiParseError $ parser templateSrc'

--- a/src/Kriti.hs
+++ b/src/Kriti.hs
@@ -13,6 +13,7 @@ where
 import qualified Data.Aeson as J
 import Data.Bifunctor (first)
 import qualified Data.ByteString as B
+import qualified Data.HashMap.Internal as Map
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as T
 import Kriti.Error
@@ -39,11 +40,11 @@ runKriti templateSrc source = do
   template' <- first KritiParseError $ parser templateSrc'
   first KritiEvalError $ runEval templateSrc' template' source
 
-runKritiWith :: T.Text -> [(T.Text, J.Value)] -> [(T.Text, J.Value -> Either CustomFunctionError J.Value)] -> Either KritiError J.Value
-runKritiWith templateSrc source funcLst = do
+runKritiWith :: T.Text -> [(T.Text, J.Value)] -> Map.HashMap T.Text (J.Value -> Either CustomFunctionError J.Value) -> Either KritiError J.Value
+runKritiWith templateSrc source funcMap = do
   let templateSrc' = T.encodeUtf8 templateSrc
   template' <- first KritiParseError $ parser templateSrc'
-  first KritiEvalError $ runEvalWith templateSrc' template' source funcLst
+  first KritiEvalError $ runEvalWith templateSrc' template' source funcMap
 
 -- | Entry point for Kriti when given a template as
 -- 'ByteString'. Caller must ensure that the input is valid UTF8

--- a/src/Kriti.hs
+++ b/src/Kriti.hs
@@ -39,7 +39,7 @@ runKriti templateSrc source = do
   template' <- first KritiParseError $ parser templateSrc'
   first KritiEvalError $ runEval templateSrc' template' source
 
-runKritiWith :: T.Text -> [(T.Text, J.Value)] -> [(T.Text, J.Value  -> Either EvalError J.Value)] -> Either KritiError J.Value
+runKritiWith :: T.Text -> [(T.Text, J.Value)] -> [(T.Text, J.Value -> Either EvalError J.Value)] -> Either KritiError J.Value
 runKritiWith templateSrc source funcLst = do
   let templateSrc' = T.encodeUtf8 templateSrc
   template' <- first KritiParseError $ parser templateSrc'

--- a/src/Kriti/CustomFunctions.hs
+++ b/src/Kriti/CustomFunctions.hs
@@ -1,84 +1,82 @@
-module Kriti.CustomFunctions
-    (basicFunctions)
-where
+module Kriti.CustomFunctions (basicFunctions) where
 
 import qualified Data.Aeson as J
-import Kriti.Error (CustomFunctionError(..))
-import qualified Data.Text as T
 import qualified Data.Scientific as S
+import qualified Data.Text as T
 import qualified Data.Vector as V
+import Kriti.Error (CustomFunctionError (..))
 
 type KritiFunc = J.Value -> Either CustomFunctionError J.Value
 
 -- | Basic custom function for Kriti.
 basicFunctions :: [(T.Text, KritiFunc)]
-basicFunctions = 
-  [ ("empty", emptyF)
-  , ("size", lengthF)
-  , ("inverse", inverseF)
-  , ("head", headF)
-  , ("tail", tailF)
-  , ("toCaseFold", toCaseFoldF)
-  , ("toLower", toLowerF)
-  , ("toUpper", toUpperF)
-  , ("toTitle", toTitleF)
+basicFunctions =
+  [ ("empty", emptyF),
+    ("size", lengthF),
+    ("inverse", inverseF),
+    ("head", headF),
+    ("tail", tailF),
+    ("toCaseFold", toCaseFoldF),
+    ("toLower", toLowerF),
+    ("toUpper", toUpperF),
+    ("toTitle", toTitleF)
   ]
 
 emptyF :: KritiFunc
 emptyF inp = case inp of
-    J.Object km -> Right .J.Bool $ null km
-    J.Array vec -> Right .J.Bool $ null vec
-    J.String txt -> Right .J.Bool $ T.strip txt == ""
-    J.Number sci -> Right .J.Bool $ sci == 0
-    J.Bool _ -> Left . CustomFunctionError $ "Cannot define emptiness for a boolean"
-    J.Null -> Right $ J.Bool True
+  J.Object km -> Right . J.Bool $ null km
+  J.Array vec -> Right . J.Bool $ null vec
+  J.String txt -> Right . J.Bool $ T.strip txt == ""
+  J.Number sci -> Right . J.Bool $ sci == 0
+  J.Bool _ -> Left . CustomFunctionError $ "Cannot define emptiness for a boolean"
+  J.Null -> Right $ J.Bool True
 
 lengthF :: KritiFunc
 lengthF inp = Right . J.Number $ case inp of
-    J.Object km -> (`S.scientific` 0) . toInteger $ length km
-    J.Array vec -> (`S.scientific` 0) . toInteger $ length vec
-    J.String txt -> (`S.scientific` 0) . toInteger $ T.length txt
-    J.Number sci -> sci
-    J.Bool b -> (`S.scientific` 0) . toInteger $ fromEnum b
-    J.Null -> 0
+  J.Object km -> (`S.scientific` 0) . toInteger $ length km
+  J.Array vec -> (`S.scientific` 0) . toInteger $ length vec
+  J.String txt -> (`S.scientific` 0) . toInteger $ T.length txt
+  J.Number sci -> sci
+  J.Bool b -> (`S.scientific` 0) . toInteger $ fromEnum b
+  J.Null -> 0
 
 inverseF :: KritiFunc
 inverseF inp = case inp of
-    J.Object km -> Right . J.Object $ km
-    J.Array vec -> Right . J.Array $ V.reverse vec
-    J.String txt -> Right . J.String $ T.reverse txt
-    J.Number sci -> Right . J.Number $ 1/sci
-    J.Bool b -> Right . J.Bool $ not b
-    J.Null -> Right J.Null
+  J.Object km -> Right . J.Object $ km
+  J.Array vec -> Right . J.Array $ V.reverse vec
+  J.String txt -> Right . J.String $ T.reverse txt
+  J.Number sci -> Right . J.Number $ 1 / sci
+  J.Bool b -> Right . J.Bool $ not b
+  J.Null -> Right J.Null
 
 headF :: KritiFunc
 headF inp = case inp of
-    J.Array vec -> Right . V.head $ vec
-    J.String txt -> Right . J.String . T.singleton . T.head $ txt
-    _ -> Left . CustomFunctionError $ "Expected an array or string"
+  J.Array vec -> Right . V.head $ vec
+  J.String txt -> Right . J.String . T.singleton . T.head $ txt
+  _ -> Left . CustomFunctionError $ "Expected an array or string"
 
 tailF :: KritiFunc
 tailF inp = case inp of
-    J.Array vec -> Right . J.Array $ V.tail vec
-    J.String txt -> Right . J.String $ T.tail txt
-    _ -> Left . CustomFunctionError $ "Expected an array or string"
+  J.Array vec -> Right . J.Array $ V.tail vec
+  J.String txt -> Right . J.String $ T.tail txt
+  _ -> Left . CustomFunctionError $ "Expected an array or string"
 
 toCaseFoldF :: KritiFunc
 toCaseFoldF inp = case inp of
-    J.String txt -> Right . J.String $ T.toCaseFold txt
-    _ -> Left . CustomFunctionError $ "Expected string"
+  J.String txt -> Right . J.String $ T.toCaseFold txt
+  _ -> Left . CustomFunctionError $ "Expected string"
 
 toLowerF :: KritiFunc
 toLowerF inp = case inp of
-    J.String txt -> Right . J.String $ T.toLower txt
-    _ -> Left . CustomFunctionError $ "Expected string"
+  J.String txt -> Right . J.String $ T.toLower txt
+  _ -> Left . CustomFunctionError $ "Expected string"
 
 toUpperF :: KritiFunc
 toUpperF inp = case inp of
-    J.String txt -> Right . J.String $ T.toUpper txt
-    _ -> Left . CustomFunctionError $ "Expected string"
+  J.String txt -> Right . J.String $ T.toUpper txt
+  _ -> Left . CustomFunctionError $ "Expected string"
 
 toTitleF :: KritiFunc
 toTitleF inp = case inp of
-    J.String txt -> Right . J.String $ T.toTitle txt
-    _ -> Left . CustomFunctionError $ "Expected string"
+  J.String txt -> Right . J.String $ T.toTitle txt
+  _ -> Left . CustomFunctionError $ "Expected string"

--- a/src/Kriti/CustomFunctions.hs
+++ b/src/Kriti/CustomFunctions.hs
@@ -51,8 +51,12 @@ inverseF inp = case inp of
 
 headF :: KritiFunc
 headF inp = case inp of
-  J.Array vec -> Right . V.head $ vec
-  J.String txt -> Right . J.String . T.singleton . T.head $ txt
+  J.Array vec -> case V.uncons vec of
+    Nothing -> Left . CustomFunctionError $ "Empty array"
+    Just (x,_) -> Right x
+  J.String txt -> case T.uncons txt of
+    Nothing -> Left . CustomFunctionError $ "Empty string"
+    Just (x,_) -> Right . J.String . T.singleton $ x
   _ -> Left . CustomFunctionError $ "Expected an array or string"
 
 tailF :: KritiFunc

--- a/src/Kriti/CustomFunctions.hs
+++ b/src/Kriti/CustomFunctions.hs
@@ -1,0 +1,84 @@
+module Kriti.CustomFunctions
+    (basicFunctions)
+where
+
+import qualified Data.Aeson as J
+import Kriti.Error (CustomFunctionError(..))
+import qualified Data.Text as T
+import qualified Data.Scientific as S
+import qualified Data.Vector as V
+
+type KritiFunc = J.Value -> Either CustomFunctionError J.Value
+
+-- | Basic custom function for Kriti.
+basicFunctions :: [(T.Text, KritiFunc)]
+basicFunctions = 
+  [ ("empty", emptyF)
+  , ("size", lengthF)
+  , ("inverse", inverseF)
+  , ("head", headF)
+  , ("tail", tailF)
+  , ("toCaseFold", toCaseFoldF)
+  , ("toLower", toLowerF)
+  , ("toUpper", toUpperF)
+  , ("toTitle", toTitleF)
+  ]
+
+emptyF :: KritiFunc
+emptyF inp = case inp of
+    J.Object km -> Right .J.Bool $ null km
+    J.Array vec -> Right .J.Bool $ null vec
+    J.String txt -> Right .J.Bool $ T.strip txt == ""
+    J.Number sci -> Right .J.Bool $ sci == 0
+    J.Bool _ -> Left . CustomFunctionError $ "Cannot define emptiness for a boolean"
+    J.Null -> Right $ J.Bool True
+
+lengthF :: KritiFunc
+lengthF inp = Right . J.Number $ case inp of
+    J.Object km -> (`S.scientific` 0) . toInteger $ length km
+    J.Array vec -> (`S.scientific` 0) . toInteger $ length vec
+    J.String txt -> (`S.scientific` 0) . toInteger $ T.length txt
+    J.Number sci -> sci
+    J.Bool b -> (`S.scientific` 0) . toInteger $ fromEnum b
+    J.Null -> 0
+
+inverseF :: KritiFunc
+inverseF inp = case inp of
+    J.Object km -> Right . J.Object $ km
+    J.Array vec -> Right . J.Array $ V.reverse vec
+    J.String txt -> Right . J.String $ T.reverse txt
+    J.Number sci -> Right . J.Number $ 1/sci
+    J.Bool b -> Right . J.Bool $ not b
+    J.Null -> Right J.Null
+
+headF :: KritiFunc
+headF inp = case inp of
+    J.Array vec -> Right . V.head $ vec
+    J.String txt -> Right . J.String . T.singleton . T.head $ txt
+    _ -> Left . CustomFunctionError $ "Expected an array or string"
+
+tailF :: KritiFunc
+tailF inp = case inp of
+    J.Array vec -> Right . J.Array $ V.tail vec
+    J.String txt -> Right . J.String $ T.tail txt
+    _ -> Left . CustomFunctionError $ "Expected an array or string"
+
+toCaseFoldF :: KritiFunc
+toCaseFoldF inp = case inp of
+    J.String txt -> Right . J.String $ T.toCaseFold txt
+    _ -> Left . CustomFunctionError $ "Expected string"
+
+toLowerF :: KritiFunc
+toLowerF inp = case inp of
+    J.String txt -> Right . J.String $ T.toLower txt
+    _ -> Left . CustomFunctionError $ "Expected string"
+
+toUpperF :: KritiFunc
+toUpperF inp = case inp of
+    J.String txt -> Right . J.String $ T.toUpper txt
+    _ -> Left . CustomFunctionError $ "Expected string"
+
+toTitleF :: KritiFunc
+toTitleF inp = case inp of
+    J.String txt -> Right . J.String $ T.toTitle txt
+    _ -> Left . CustomFunctionError $ "Expected string"

--- a/src/Kriti/CustomFunctions.hs
+++ b/src/Kriti/CustomFunctions.hs
@@ -1,6 +1,19 @@
-module Kriti.CustomFunctions (basicFunctions) where
+module Kriti.CustomFunctions
+  ( basicFuncMap,
+    emptyF,
+    lengthF,
+    inverseF,
+    headF,
+    tailF,
+    toCaseFoldF,
+    toLowerF,
+    toUpperF,
+    toTitleF,
+  )
+where
 
 import qualified Data.Aeson as J
+import qualified Data.HashMap.Internal as Map
 import qualified Data.Scientific as S
 import qualified Data.Text as T
 import qualified Data.Vector as V
@@ -9,18 +22,19 @@ import Kriti.Error (CustomFunctionError (..))
 type KritiFunc = J.Value -> Either CustomFunctionError J.Value
 
 -- | Basic custom function for Kriti.
-basicFunctions :: [(T.Text, KritiFunc)]
-basicFunctions =
-  [ ("empty", emptyF),
-    ("size", lengthF),
-    ("inverse", inverseF),
-    ("head", headF),
-    ("tail", tailF),
-    ("toCaseFold", toCaseFoldF),
-    ("toLower", toLowerF),
-    ("toUpper", toUpperF),
-    ("toTitle", toTitleF)
-  ]
+basicFuncMap :: Map.HashMap T.Text KritiFunc
+basicFuncMap =
+  Map.fromList
+    [ ("empty", emptyF),
+      ("size", lengthF),
+      ("inverse", inverseF),
+      ("head", headF),
+      ("tail", tailF),
+      ("toCaseFold", toCaseFoldF),
+      ("toLower", toLowerF),
+      ("toUpper", toUpperF),
+      ("toTitle", toTitleF)
+    ]
 
 emptyF :: KritiFunc
 emptyF inp = case inp of

--- a/src/Kriti/CustomFunctions.hs
+++ b/src/Kriti/CustomFunctions.hs
@@ -53,10 +53,10 @@ headF :: KritiFunc
 headF inp = case inp of
   J.Array vec -> case V.uncons vec of
     Nothing -> Left . CustomFunctionError $ "Empty array"
-    Just (x,_) -> Right x
+    Just (x, _) -> Right x
   J.String txt -> case T.uncons txt of
     Nothing -> Left . CustomFunctionError $ "Empty string"
-    Just (x,_) -> Right . J.String . T.singleton $ x
+    Just (x, _) -> Right . J.String . T.singleton $ x
   _ -> Left . CustomFunctionError $ "Expected an array or string"
 
 tailF :: KritiFunc

--- a/src/Kriti/Error.hs
+++ b/src/Kriti/Error.hs
@@ -12,8 +12,10 @@ data ErrorCode
   | RangeErrorCode
   | ParseErrorCode
   | LexErrorCode
-  | CustomErrorCode
+  | FunctionErrorCode
   deriving (Show)
+
+newtype CustomFunctionError = CustomFunctionError {unwrapError :: T.Text}
 
 instance Pretty ErrorCode where
   pretty = \case
@@ -22,7 +24,7 @@ instance Pretty ErrorCode where
     RangeErrorCode -> "Out of Range Error"
     ParseErrorCode -> "Parse Error"
     LexErrorCode -> "Lex Error"
-    CustomErrorCode -> "Custom Error"
+    FunctionErrorCode -> "Function Error"
 
 data SerializedError = SerializedError {_code :: ErrorCode, _message :: T.Text, _span :: S.Span}
   deriving (Show)

--- a/src/Kriti/Error.hs
+++ b/src/Kriti/Error.hs
@@ -12,6 +12,7 @@ data ErrorCode
   | RangeErrorCode
   | ParseErrorCode
   | LexErrorCode
+  | CustomErrorCode
   deriving (Show)
 
 instance Pretty ErrorCode where
@@ -21,6 +22,7 @@ instance Pretty ErrorCode where
     RangeErrorCode -> "Out of Range Error"
     ParseErrorCode -> "Parse Error"
     LexErrorCode -> "Lex Error"
+    CustomErrorCode -> "Custom Error"
 
 data SerializedError = SerializedError {_code :: ErrorCode, _message :: T.Text, _span :: S.Span}
   deriving (Show)

--- a/src/Kriti/Eval.hs
+++ b/src/Kriti/Eval.hs
@@ -40,9 +40,9 @@ instance Pretty EvalError where
          in vsep
               [ "Runtime Error:",
                 indent 2 $ pretty (msg :: T.Text),
-                indent (startLine + 1) "|",
-                pretty startLine <+> "|" <+> pretty (TE.decodeUtf8 sourceLine),
-                indent (startLine + 1) $ "|" <> indent (startCol) (pretty $ replicate (endCol - startCol) '^')
+                indent 4 "|",
+                indent 2 $ pretty startLine  <+> "|" <+> pretty (TE.decodeUtf8 sourceLine),
+                indent 4 $ "|" <> indent (startCol) (pretty $ replicate (endCol - startCol) '^')
               ]
 
 instance SerializeError EvalError where
@@ -199,7 +199,7 @@ evalWith funcMap = \case
     case Map.lookup fName funcMap of
       Nothing -> throwError $ FunctionError src sp $ "Function " <> fName <> " is not defined."
       Just f -> case f v1 of
-        Left ee -> throwError $ FunctionError src sp $ unwrapError ee
+        Left ee -> throwError $ FunctionError src (locate t1) $ unwrapError ee
         Right va -> pure va
   Defaulting _ t1 t2 -> do
     v1 <- eval t1

--- a/src/Kriti/Eval.hs
+++ b/src/Kriti/Eval.hs
@@ -206,7 +206,7 @@ evalWith funcMap = \case
     src <- asks fst
     v1 <- eval t1
     case Map.lookup fName funcMap of
-      Nothing -> throwError $ TypeError src sp $ "Function " <> fName <> " definition not found."
+      Nothing -> throwError $ FuncNotFound src sp $ "Function " <> fName <> " definition not found."
       Just f -> case f v1 of
         Left ee -> throwError ee
         Right va -> pure va

--- a/src/Kriti/Eval.hs
+++ b/src/Kriti/Eval.hs
@@ -81,10 +81,9 @@ runEval src template source =
   let ctx = Compat.fromList source
    in runReader (runExceptT (evalWith Map.empty template)) (src, ctx)
 
-runEvalWith :: B.ByteString -> ValueExt -> [(T.Text, J.Value)] -> [(T.Text, J.Value -> Either CustomFunctionError J.Value)] -> Either EvalError J.Value
-runEvalWith src template source functionLst =
+runEvalWith :: B.ByteString -> ValueExt -> [(T.Text, J.Value)] -> Map.HashMap T.Text (J.Value -> Either CustomFunctionError J.Value) -> Either EvalError J.Value
+runEvalWith src template source funcMap =
   let ctx = Compat.fromList source
-      funcMap = Map.fromList functionLst
    in runReader (runExceptT (evalWith funcMap template)) (src, ctx)
 
 typoOfJSON :: J.Value -> T.Text

--- a/src/Kriti/Eval.hs
+++ b/src/Kriti/Eval.hs
@@ -53,12 +53,12 @@ instance SerializeError EvalError where
   serialize (TypeError _ term msg) = SerializedError {_code = TypeErrorCode, _message = msg, _span = locate term}
   serialize (RangeError _ term) = SerializedError {_code = RangeErrorCode, _message = "Can only range over an array", _span = locate term}
   serialize (FuncNotFound _ term msg) = SerializedError {_code = TypeErrorCode, _message = msg, _span = locate term}
-  serialize (CustomError  msg) = SerializedError {_code = CustomErrorCode , _message = msg, _span = dummySpan}
+  serialize (CustomError msg) = SerializedError {_code = CustomErrorCode, _message = msg, _span = dummySpan}
 
 dummySpan :: Span
 dummySpan = Span dummyPos dummyPos
-  where dummyPos = AlexSourcePos 0 0
-
+  where
+    dummyPos = AlexSourcePos 0 0
 
 type Ctxt = (B.ByteString, Compat.Object J.Value)
 
@@ -67,7 +67,7 @@ getSourcePos (InvalidPath _ pos _) = locate pos
 getSourcePos (TypeError _ term _) = locate term
 getSourcePos (RangeError _ pos) = locate pos
 getSourcePos (FuncNotFound _ term _) = locate term
-getSourcePos (CustomError _ ) = dummySpan
+getSourcePos (CustomError _) = dummySpan
 
 evalPath :: Span -> J.Value -> V.Vector (Accessor) -> ExceptT EvalError (Reader Ctxt) J.Value
 evalPath sp ctx path = do
@@ -215,4 +215,5 @@ evalWith funcMap = \case
     case v1 of
       J.Null -> eval t2
       json -> pure json
-  where eval = evalWith funcMap
+  where
+    eval = evalWith funcMap

--- a/src/Kriti/Eval.hs
+++ b/src/Kriti/Eval.hs
@@ -41,7 +41,7 @@ instance Pretty EvalError where
               [ "Runtime Error:",
                 indent 2 $ pretty (msg :: T.Text),
                 indent 4 "|",
-                indent 2 $ pretty startLine  <+> "|" <+> pretty (TE.decodeUtf8 sourceLine),
+                indent 2 $ pretty startLine <+> "|" <+> pretty (TE.decodeUtf8 sourceLine),
                 indent 4 $ "|" <> indent (startCol) (pretty $ replicate (endCol - startCol) '^')
               ]
 

--- a/src/Kriti/Parser/Grammar.y
+++ b/src/Kriti/Parser/Grammar.y
@@ -72,9 +72,9 @@ ident       { TokIdentifier $$ }
 ')'         { TokSymbol (Loc $$ SymParenClose) }
 
 %right 'in' 
-%nonassoc '>' '<' '<=' '>=' '==' '!=' '&&' '||' 
+%nonassoc '>' '<' '<=' '>=' '==' '!=' '&&' '||' ident 
 %left '??' 
-%left 'not' 'escapeUri'
+%left 'not' 'escapeUri' 
 
 %%
 

--- a/src/Kriti/Parser/Grammar.y
+++ b/src/Kriti/Parser/Grammar.y
@@ -44,7 +44,6 @@ string      { TokStringLit $$ }
 'escapeUri' { TokIdentifier (Loc $$ "escapeUri") }
 'not'       { TokIdentifier (Loc $$ "not") }
 'in'        { TokIdentifier (Loc $$ "in") }
-'customFunc'{ TokIdentifier (Loc $$ "customFunc") }
 ident       { TokIdentifier $$ }
 
 '\''        { TokSymbol (Loc $$ SymSingleQuote) }
@@ -75,7 +74,7 @@ ident       { TokIdentifier $$ }
 %right 'in' 
 %nonassoc '>' '<' '<=' '>=' '==' '!=' '&&' '||' 
 %left '??' 
-%left 'not' 'escapeUri' 'customFunc'
+%left 'not' 'escapeUri'
 
 %%
 

--- a/src/Kriti/Parser/Grammar.y
+++ b/src/Kriti/Parser/Grammar.y
@@ -44,6 +44,7 @@ string      { TokStringLit $$ }
 'escapeUri' { TokIdentifier (Loc $$ "escapeUri") }
 'not'       { TokIdentifier (Loc $$ "not") }
 'in'        { TokIdentifier (Loc $$ "in") }
+'customFunc'{ TokIdentifier (Loc $$ "customFunc") }
 ident       { TokIdentifier $$ }
 
 '\''        { TokSymbol (Loc $$ SymSingleQuote) }
@@ -74,7 +75,7 @@ ident       { TokIdentifier $$ }
 %right 'in' 
 %nonassoc '>' '<' '<=' '>=' '==' '!=' '&&' '||' 
 %left '??' 
-%left 'not' 'escapeUri'
+%left 'not' 'escapeUri' 'customFunc'
 
 %%
 
@@ -144,6 +145,7 @@ function :: { ValueExt }
 function
   : 'escapeUri' kritiValue { buildFunc EscapeURI (locate $1) $2 }
   | 'not' kritiValue { buildFunc Not (locate $1) $2 }
+  | 'customFunc' kritiValue { buildFunc CustomFunc (locate $1) $2 }
 
 range :: { ValueExt }
 range

--- a/src/Kriti/Parser/Grammar.y
+++ b/src/Kriti/Parser/Grammar.y
@@ -145,7 +145,7 @@ function :: { ValueExt }
 function
   : 'escapeUri' kritiValue { buildFunc EscapeURI (locate $1) $2 }
   | 'not' kritiValue { buildFunc Not (locate $1) $2 }
-  | 'customFunc' kritiValue { buildFunc CustomFunc (locate $1) $2 }
+  | ident kritiValue { Function (locate $1) (unLoc $1) $2 }
 
 range :: { ValueExt }
 range

--- a/src/Kriti/Parser/Lexer.x
+++ b/src/Kriti/Parser/Lexer.x
@@ -24,6 +24,7 @@ tokens :-
 -- Syntax
 <0> range                                      { token TokIdentifier }
 <0> not                                        { token TokIdentifier }
+<0> customFunc                                 { token TokIdentifier }
 <0, expr> true                                 { token (TokBoolLit . (\(Loc sp _) -> Loc sp True)) }
 <0, expr> false                                { token (TokBoolLit . (\(Loc sp _) -> Loc sp False)) }
 <0, expr> \$                                   { token TokIdentifier }

--- a/src/Kriti/Parser/Lexer.x
+++ b/src/Kriti/Parser/Lexer.x
@@ -24,7 +24,6 @@ tokens :-
 -- Syntax
 <0> range                                      { token TokIdentifier }
 <0> not                                        { token TokIdentifier }
-<0> customFunc                                 { token TokIdentifier }
 <0, expr> true                                 { token (TokBoolLit . (\(Loc sp _) -> Loc sp True)) }
 <0, expr> false                                { token (TokBoolLit . (\(Loc sp _) -> Loc sp False)) }
 <0, expr> \$                                   { token TokIdentifier }

--- a/src/Kriti/Parser/Token.hs
+++ b/src/Kriti/Parser/Token.hs
@@ -154,7 +154,7 @@ data ValueExt
   | Defaulting Span ValueExt ValueExt
   | Range Span (Maybe T.Text) T.Text (V.Vector Accessor) ValueExt
   | EscapeURI Span ValueExt
-  | CustomFunc Span ValueExt
+  | Function Span T.Text ValueExt
   deriving (Show, Eq, Read, Generic)
 
 instance Located ValueExt where
@@ -181,7 +181,7 @@ instance Located ValueExt where
     Defaulting s _ _ -> s
     Range s _ _ _ _ -> s
     EscapeURI s _ -> s
-    CustomFunc s _ -> s
+    Function s _ _ -> s
 
 instance Located Accessor where
   locate = \case
@@ -231,7 +231,7 @@ instance Pretty ValueExt where
           "{{" <+> "end" <+> "}}"
         ]
     EscapeURI _ t1 -> "{{" <+> "escapeUri" <+> pretty t1 <+> "}}"
-    CustomFunc _ t1 -> "{{" <+> "customFunc" <+> pretty t1 <+> "}}"
+    Function _ n t1 -> "{{" <+> pretty n <+> " {{"<+> pretty t1 <+> "}} }}"
 
 renderDoc :: Doc ann -> T.Text
 renderDoc = renderStrict . layoutPretty defaultLayoutOptions

--- a/src/Kriti/Parser/Token.hs
+++ b/src/Kriti/Parser/Token.hs
@@ -154,6 +154,7 @@ data ValueExt
   | Defaulting Span ValueExt ValueExt
   | Range Span (Maybe T.Text) T.Text (V.Vector Accessor) ValueExt
   | EscapeURI Span ValueExt
+  | CustomFunc Span ValueExt
   deriving (Show, Eq, Read, Generic)
 
 instance Located ValueExt where
@@ -180,6 +181,7 @@ instance Located ValueExt where
     Defaulting s _ _ -> s
     Range s _ _ _ _ -> s
     EscapeURI s _ -> s
+    CustomFunc s _ -> s
 
 instance Located Accessor where
   locate = \case
@@ -229,6 +231,7 @@ instance Pretty ValueExt where
           "{{" <+> "end" <+> "}}"
         ]
     EscapeURI _ t1 -> "{{" <+> "escapeUri" <+> pretty t1 <+> "}}"
+    CustomFunc _ t1 -> "{{" <+> "customFunc" <+> pretty t1 <+> "}}"
 
 renderDoc :: Doc ann -> T.Text
 renderDoc = renderStrict . layoutPretty defaultLayoutOptions

--- a/src/Kriti/Parser/Token.hs
+++ b/src/Kriti/Parser/Token.hs
@@ -231,7 +231,7 @@ instance Pretty ValueExt where
           "{{" <+> "end" <+> "}}"
         ]
     EscapeURI _ t1 -> "{{" <+> "escapeUri" <+> pretty t1 <+> "}}"
-    Function _ n t1 -> "{{" <+> pretty n <+> " {{"<+> pretty t1 <+> "}} }}"
+    Function _ n t1 -> "{{" <+> pretty n <+> " {{" <+> pretty t1 <+> "}} }}"
 
 renderDoc :: Doc ann -> T.Text
 renderDoc = renderStrict . layoutPretty defaultLayoutOptions

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -38,6 +38,7 @@ import qualified Test.QuickCheck as Q
 import qualified Test.QuickCheck.Arbitrary.Generic as QAG
 import Text.Pretty.Simple (pShowNoColor)
 import Text.Read (readEither)
+import Kriti.CustomFunctions
 
 --------------------------------------------------------------------------------
 
@@ -110,12 +111,12 @@ evalJson :: J.Value -> Either T.Text J.Value
 evalJson value = do
   let enc = BL.toStrict $ J.encode value
   ast <- first renderPretty $ P.parser enc
-  first renderPretty $ runEval enc ast []
+  first renderPretty $ runEvalWith enc ast [] basicFunctions
 
 evalBS :: BS.ByteString -> Either T.Text J.Value
 evalBS input = do
   ast <- first renderPretty $ P.parser input
-  first renderPretty $ runEval "" ast []
+  first renderPretty $ runEvalWith "" ast [] basicFunctions
 
 -- | Encode a JSON value as 'T.Text'.
 encodeText :: J.Value -> T.Text
@@ -218,7 +219,7 @@ evalGoldenSpec = describe "Golden" do
 evalSuccess :: J.Value -> FilePath -> IO J.Value
 evalSuccess source path = do
   (src, tmpl) <- parseTemplateSuccess path
-  either throwString pure $ either (Left . show) Right $ runEval src tmpl [("$", source)]
+  either throwString pure $ either (Left . show) Right $ runEvalWith src tmpl [("$", source)] basicFunctions
 
 --------------------------------------------------------------------------------
 -- Golden test construction functions.

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -27,6 +27,7 @@ import qualified Data.Vector as V
 import Data.Monoid
 import Kriti
 import qualified Kriti.Aeson.Compat as Compat
+import Kriti.CustomFunctions
 import Kriti.Error
 import Kriti.Eval
 import qualified Kriti.Parser as P
@@ -38,7 +39,6 @@ import qualified Test.QuickCheck as Q
 import qualified Test.QuickCheck.Arbitrary.Generic as QAG
 import Text.Pretty.Simple (pShowNoColor)
 import Text.Read (readEither)
-import Kriti.CustomFunctions
 
 --------------------------------------------------------------------------------
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -111,12 +111,12 @@ evalJson :: J.Value -> Either T.Text J.Value
 evalJson value = do
   let enc = BL.toStrict $ J.encode value
   ast <- first renderPretty $ P.parser enc
-  first renderPretty $ runEvalWith enc ast [] basicFunctions
+  first renderPretty $ runEvalWith enc ast [] basicFuncMap
 
 evalBS :: BS.ByteString -> Either T.Text J.Value
 evalBS input = do
   ast <- first renderPretty $ P.parser input
-  first renderPretty $ runEvalWith "" ast [] basicFunctions
+  first renderPretty $ runEvalWith "" ast [] basicFuncMap
 
 -- | Encode a JSON value as 'T.Text'.
 encodeText :: J.Value -> T.Text
@@ -219,7 +219,7 @@ evalGoldenSpec = describe "Golden" do
 evalSuccess :: J.Value -> FilePath -> IO J.Value
 evalSuccess source path = do
   (src, tmpl) <- parseTemplateSuccess path
-  either throwString pure $ either (Left . show) Right $ runEvalWith src tmpl [("$", source)] basicFunctions
+  either throwString pure $ either (Left . show) Right $ runEvalWith src tmpl [("$", source)] basicFuncMap
 
 --------------------------------------------------------------------------------
 -- Golden test construction functions.

--- a/test/data/eval/success/examples/example23.kriti
+++ b/test/data/eval/success/examples/example23.kriti
@@ -1,0 +1,13 @@
+{
+    "agents":
+    {{ range i, x := $ }}
+        {
+            "agent_id" : {{ toLower x.guid }},
+            "friends" : {{ size x.friends }},
+            "gender" : {{toUpper (head x.gender)}},
+            "money" : {{tail x.balance}},
+            "tags" : {{ not (empty x.tags) }},
+            "agent_name" : {{ toTitle (inverse x.name) }}
+        }
+    {{ end }}
+}

--- a/test/data/eval/success/golden/example23.json
+++ b/test/data/eval/success/golden/example23.json
@@ -1,0 +1,44 @@
+{
+    "agents": [
+        {
+            "agent_id": "43a922da-9665-4099-8dfc-f9af369695a4",
+            "agent_name": "Llaccm Drapehs",
+            "friends": 3,
+            "gender": "M",
+            "money": "1,179.12",
+            "tags": true
+        },
+        {
+            "agent_id": "d6efff1c-fdf3-4987-9d34-04327a7f79b1",
+            "agent_name": "Enyap Adnaw",
+            "friends": 3,
+            "gender": "F",
+            "money": "1,227.32",
+            "tags": true
+        },
+        {
+            "agent_id": "2aef760f-f494-491d-8a02-55aaa50eb242",
+            "agent_name": "Revooh Nielk",
+            "friends": 3,
+            "gender": "M",
+            "money": "1,510.90",
+            "tags": true
+        },
+        {
+            "agent_id": "0bcf5ea6-8e7a-4e1d-aaf3-0994535c004d",
+            "agent_name": "Arreug Ennaid",
+            "friends": 3,
+            "gender": "F",
+            "money": "2,551.65",
+            "tags": true
+        },
+        {
+            "agent_id": "8ca357de-994e-433d-af8c-d232bbab437a",
+            "agent_name": "Snehpets Adnov",
+            "friends": 3,
+            "gender": "F",
+            "money": "2,695.48",
+            "tags": true
+        }
+    ]
+}

--- a/test/data/parser/success/examples/customFunctions.kriti
+++ b/test/data/parser/success/examples/customFunctions.kriti
@@ -1,0 +1,9 @@
+# function calls
+[ {{ head "foo" }},
+  {{ not (empty (tail "f")) }},
+  {{ size $path[0] }},
+  {{ inverse [1,2,3,4,5,6,7,8,9] }},
+  {{ toUpper "hello world"}},
+  {{ toTitle "hELLO wORLD"}},
+  {{ toLower "HELLO WORLD"}}
+]

--- a/test/data/parser/success/golden/customFunctions.txt
+++ b/test/data/parser/success/golden/customFunctions.txt
@@ -1,0 +1,413 @@
+Array
+    ( Span
+        { start = AlexSourcePos
+            { line = 1
+            , col = 1
+            }
+        , end = AlexSourcePos
+            { line = 8
+            , col = 2
+            }
+        }
+    )
+    [ Function
+        ( Span
+            { start = AlexSourcePos
+                { line = 1
+                , col = 6
+                }
+            , end = AlexSourcePos
+                { line = 1
+                , col = 10
+                }
+            }
+        ) "head"
+        ( StringTem
+            ( Span
+                { start = AlexSourcePos
+                    { line = 1
+                    , col = 11
+                    }
+                , end = AlexSourcePos
+                    { line = 1
+                    , col = 16
+                    }
+                }
+            )
+            [ String
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 1
+                        , col = 12
+                        }
+                    , end = AlexSourcePos
+                        { line = 1
+                        , col = 15
+                        }
+                    }
+                ) "foo"
+            ]
+        )
+    , Not
+        ( Span
+            { start = AlexSourcePos
+                { line = 2
+                , col = 6
+                }
+            , end = AlexSourcePos
+                { line = 2
+                , col = 16
+                }
+            }
+        )
+        ( Function
+            ( Span
+                { start = AlexSourcePos
+                    { line = 2
+                    , col = 11
+                    }
+                , end = AlexSourcePos
+                    { line = 2
+                    , col = 16
+                    }
+                }
+            ) "empty"
+            ( Function
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 2
+                        , col = 18
+                        }
+                    , end = AlexSourcePos
+                        { line = 2
+                        , col = 22
+                        }
+                    }
+                ) "tail"
+                ( StringTem
+                    ( Span
+                        { start = AlexSourcePos
+                            { line = 2
+                            , col = 23
+                            }
+                        , end = AlexSourcePos
+                            { line = 2
+                            , col = 26
+                            }
+                        }
+                    )
+                    [ String
+                        ( Span
+                            { start = AlexSourcePos
+                                { line = 2
+                                , col = 24
+                                }
+                            , end = AlexSourcePos
+                                { line = 2
+                                , col = 25
+                                }
+                            }
+                        ) "f"
+                    ]
+                )
+            )
+        )
+    , Function
+        ( Span
+            { start = AlexSourcePos
+                { line = 3
+                , col = 6
+                }
+            , end = AlexSourcePos
+                { line = 3
+                , col = 10
+                }
+            }
+        ) "size"
+        ( Path
+            ( Span
+                { start = AlexSourcePos
+                    { line = 3
+                    , col = 11
+                    }
+                , end = AlexSourcePos
+                    { line = 3
+                    , col = 19
+                    }
+                }
+            )
+            [ Obj
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 3
+                        , col = 11
+                        }
+                    , end = AlexSourcePos
+                        { line = 3
+                        , col = 16
+                        }
+                    }
+                ) NotOptional "$path" Head
+            , Arr
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 3
+                        , col = 16
+                        }
+                    , end = AlexSourcePos
+                        { line = 3
+                        , col = 19
+                        }
+                    }
+                ) NotOptional 0
+            ]
+        )
+    , Function
+        ( Span
+            { start = AlexSourcePos
+                { line = 4
+                , col = 6
+                }
+            , end = AlexSourcePos
+                { line = 4
+                , col = 13
+                }
+            }
+        ) "inverse"
+        ( Array
+            ( Span
+                { start = AlexSourcePos
+                    { line = 4
+                    , col = 14
+                    }
+                , end = AlexSourcePos
+                    { line = 4
+                    , col = 33
+                    }
+                }
+            )
+            [ Number
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 4
+                        , col = 15
+                        }
+                    , end = AlexSourcePos
+                        { line = 4
+                        , col = 16
+                        }
+                    }
+                ) 1.0
+            , Number
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 4
+                        , col = 17
+                        }
+                    , end = AlexSourcePos
+                        { line = 4
+                        , col = 18
+                        }
+                    }
+                ) 2.0
+            , Number
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 4
+                        , col = 19
+                        }
+                    , end = AlexSourcePos
+                        { line = 4
+                        , col = 20
+                        }
+                    }
+                ) 3.0
+            , Number
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 4
+                        , col = 21
+                        }
+                    , end = AlexSourcePos
+                        { line = 4
+                        , col = 22
+                        }
+                    }
+                ) 4.0
+            , Number
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 4
+                        , col = 23
+                        }
+                    , end = AlexSourcePos
+                        { line = 4
+                        , col = 24
+                        }
+                    }
+                ) 5.0
+            , Number
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 4
+                        , col = 25
+                        }
+                    , end = AlexSourcePos
+                        { line = 4
+                        , col = 26
+                        }
+                    }
+                ) 6.0
+            , Number
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 4
+                        , col = 27
+                        }
+                    , end = AlexSourcePos
+                        { line = 4
+                        , col = 28
+                        }
+                    }
+                ) 7.0
+            , Number
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 4
+                        , col = 29
+                        }
+                    , end = AlexSourcePos
+                        { line = 4
+                        , col = 30
+                        }
+                    }
+                ) 8.0
+            , Number
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 4
+                        , col = 31
+                        }
+                    , end = AlexSourcePos
+                        { line = 4
+                        , col = 32
+                        }
+                    }
+                ) 9.0
+            ]
+        )
+    , Function
+        ( Span
+            { start = AlexSourcePos
+                { line = 5
+                , col = 6
+                }
+            , end = AlexSourcePos
+                { line = 5
+                , col = 13
+                }
+            }
+        ) "toUpper"
+        ( StringTem
+            ( Span
+                { start = AlexSourcePos
+                    { line = 5
+                    , col = 14
+                    }
+                , end = AlexSourcePos
+                    { line = 5
+                    , col = 27
+                    }
+                }
+            )
+            [ String
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 5
+                        , col = 15
+                        }
+                    , end = AlexSourcePos
+                        { line = 5
+                        , col = 26
+                        }
+                    }
+                ) "hello world"
+            ]
+        )
+    , Function
+        ( Span
+            { start = AlexSourcePos
+                { line = 6
+                , col = 6
+                }
+            , end = AlexSourcePos
+                { line = 6
+                , col = 13
+                }
+            }
+        ) "toTitle"
+        ( StringTem
+            ( Span
+                { start = AlexSourcePos
+                    { line = 6
+                    , col = 14
+                    }
+                , end = AlexSourcePos
+                    { line = 6
+                    , col = 27
+                    }
+                }
+            )
+            [ String
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 6
+                        , col = 15
+                        }
+                    , end = AlexSourcePos
+                        { line = 6
+                        , col = 26
+                        }
+                    }
+                ) "hELLO wORLD"
+            ]
+        )
+    , Function
+        ( Span
+            { start = AlexSourcePos
+                { line = 7
+                , col = 6
+                }
+            , end = AlexSourcePos
+                { line = 7
+                , col = 13
+                }
+            }
+        ) "toLower"
+        ( StringTem
+            ( Span
+                { start = AlexSourcePos
+                    { line = 7
+                    , col = 14
+                    }
+                , end = AlexSourcePos
+                    { line = 7
+                    , col = 27
+                    }
+                }
+            )
+            [ String
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 7
+                        , col = 15
+                        }
+                    , end = AlexSourcePos
+                        { line = 7
+                        , col = 26
+                        }
+                    }
+                ) "HELLO WORLD"
+            ]
+        )
+    ]


### PR DESCRIPTION
## Description
This PR adds the support of custom functions.
Proposed `runKritiWith` function with the following type:
``` haskell
runKritiWith ::
    T.Text -> 
    [(T.Text, J.Value)] -> 
    [(T.Text, J.Value  -> Either CustomFunctionError J.Value)] -> 
    Either KritiError J.Value
```
Here, `(T.Text, J.Value  -> Either CustomFunctionError J.Value)` is a tuple provided by the user, where the first element is the name of the function and second element is the function. For using this custom function, user would have to specify it in the template.

<details close><summary><b>Click here for an example.</b></summary>

Template:
```
{
  "author": {
    "name": {{$.event.name}},
    "age": {{$.event.age}},
    "articles":
      {{ range _, x := $.event.author.articles }}
          {
              "id": {{x.id}},
              "title": {{customFunc x.title}}
          }
      {{ end }}
  }
}
```
Input:
```
{
  "event": {
    "name": "Freddie Jones",
    "age": 27,
    "author": {
      "articles": [
        { "id": 0, "title": "The Elements", "length": 150, "published": true},
        { "id": 1, "title": "ARRL Handbook", "length": 1000, "published": true},
        { "id": 2, "title": "The Mars Trilogy", "length": 500, "published": false}
      ]
    }
  }
}
```
Output:
```
{
  "author": {
    "age": 27,
    "articles": [
      {
        "id": 0,
        "title": "THE ELEMENTS"
      },
      {
        "id": 1,
        "title": "ARRL HANDBOOK"
      },
      {
        "id": 2,
        "title": "THE MARS TRILOGY"
      }
    ],
    "name": "Freddie Jones"
  }
}
```
Where customFunc is defined as:
``` haskell
uppercased :: J.Value -> Either CustomFunctionError J.Value
uppercased inp = case inp of
  J.String txt -> Right $ J.String (T.toUpper txt)
  _ -> Left $ CustomFunctionError "unexpected"
```
</details>

## TODOs
- [x] Add RFC: https://github.com/hasura/kriti-lang/pull/49
- [x] Add support for user supplied custom function name
- [x] Add example of a usecase of custom function.
- [x] Add ability to use multiple user defined functions.

## Future scope (can be taken up in separate PR)
- Wrap the function inside the `Function` wrapper instead of passing to evaluator.
- Don't split up the evaluator as `eval` and `evalWith`.
- Add some more basic custom functions.
- Extend this beyond unary functions.