### PR TITLE
Require parens when parsing function application

### DIFF
--- a/grammar.bnf
+++ b/grammar.bnf
@@ -1,9 +1,9 @@
 %right 'in'
 %right LOW
 %right ']'
-%nonassoc '>' '<' '<=' '>=' '==' '!=' '&&' '||' ident
+%nonassoc '>' '<' '<=' '>=' '==' '!=' '&&' '||'
 %left '??'
-%left 'not' 'escapeUri'
+%left ident 'not'
 
 expr
   : json
@@ -59,9 +59,8 @@ operator
   | kritiValue '??' kritiValue
 
 function
-  : 'escapeUri' kritiValue
+  : ident '(' kritiValue ')'
   | 'not' kritiValue
-  | ident kritiValue
 
 range
   : '{{' 'range' mident ',' ident ':=' path_vector '}}' expr '{{' 'end' '}}'

--- a/src/Kriti/Parser/Grammar.y
+++ b/src/Kriti/Parser/Grammar.y
@@ -42,6 +42,7 @@ string      { TokStringLit $$ }
 'null'      { TokIdentifier (Loc $$ "null" ) }
 'range'     { TokIdentifier (Loc $$ "range") }
 'in'        { TokIdentifier (Loc $$ "in") }
+'not'       { TokIdentifier (Loc $$ "not") }
 ident       { TokIdentifier $$ }
 
 '\''        { TokSymbol (Loc $$ SymSingleQuote) }
@@ -76,7 +77,7 @@ ident       { TokIdentifier $$ }
 %nonassoc '>' '<' '<=' '>=' '==' '!=' '&&' '||' 
 
 %left '??' 
-%left ident 
+%left ident 'not'
 
 %%
 
@@ -145,7 +146,8 @@ operator
 
 function :: { ValueExt }
 function
-  : ident kritiValue { Function (locate $1) (unLoc $1) $2 }
+  : ident '(' kritiValue ')' { Function (locate $1 <> locate $4) (unLoc $1) $3 }
+  | 'not' kritiValue { Function (locate $1 <> locate $2) "not" $2 }
 
 range :: { ValueExt }
 range

--- a/test/data/eval/success/examples/example13.kriti
+++ b/test/data/eval/success/examples/example13.kriti
@@ -1,1 +1,1 @@
-{{ escapeUri "?foo=bar/baz" }}
+{{ escapeUri("?foo=bar/baz") }}

--- a/test/data/eval/success/examples/example16.kriti
+++ b/test/data/eval/success/examples/example16.kriti
@@ -1,1 +1,1 @@
-{{ escapeUri $[0].email }}
+{{ escapeUri($[0].email) }}

--- a/test/data/eval/success/examples/example17.kriti
+++ b/test/data/eval/success/examples/example17.kriti
@@ -1,1 +1,1 @@
-"{{ escapeUri $[0].email }}"
+"{{ escapeUri($[0].email) }}"

--- a/test/data/eval/success/examples/example23.kriti
+++ b/test/data/eval/success/examples/example23.kriti
@@ -2,12 +2,12 @@
     "agents":
     {{ range i, x := $ }}
         {
-            "agent_id" : {{ toLower x.guid }},
-            "friends" : {{ size x.friends }},
-            "gender" : {{toUpper (head x.gender)}},
-            "money" : {{tail x.balance}},
-            "tags" : {{ not (empty x.tags) }},
-            "agent_name" : {{ toTitle (inverse x.name) }}
+            "agent_id" : {{ toLower(x.guid) }},
+            "friends" : {{ size(x.friends) }},
+            "gender" : {{toUpper(head(x.gender))}},
+            "money" : {{tail(x.balance)}},
+            "tags" : {{ not(empty(x.tags)) }},
+            "agent_name" : {{ toTitle(inverse(x.name)) }}
         }
     {{ end }}
 }

--- a/test/data/eval/success/examples/example24.kriti
+++ b/test/data/eval/success/examples/example24.kriti
@@ -1,20 +1,20 @@
 {
     "agents":
-    {{ removeNulls
+    {{ removeNulls(
         {{ range i, x := $ }}
             {{ if i > 2 }}
-                {{ fromPairs [
-                        ["agent_id", {{ toLower x.guid }}],
-                        ["friends", {{ size x.friends }}],
-                        ["gender", {{toUpper (head x.gender)}}],
-                        ["money", {{tail x.balance}}],
-                        ["tags", {{ not (empty x.tags) }}],
-                        ["agent_name", {{ toTitle (inverse x.name) }}]
-                    ]
+                {{ fromPairs([
+                        ["agent_id", {{ toLower(x.guid) }}],
+                        ["friends", {{ size(x.friends) }}],
+                        ["gender", {{toUpper(head(x.gender))}}],
+                        ["money", {{tail(x.balance)}}],
+                        ["tags", {{ not (empty(x.tags)) }}],
+                        ["agent_name", {{ toTitle(inverse(x.name)) }}]
+                    ])
                 }}
             {{ else }}
                 null
             {{ end }}
-        {{ end }}
+        {{ end }})
     }}
 }

--- a/test/data/eval/success/examples/example25.kriti
+++ b/test/data/eval/success/examples/example25.kriti
@@ -1,8 +1,8 @@
 {
     "arrays":
-        {{ concat
+        {{ concat(
             {{ range i, x := $ }}
                 [ {{ i }}, {{ i }} ]
-            {{ end }}
+            {{ end }})
         }}
 }

--- a/test/data/eval/success/examples/example26.kriti
+++ b/test/data/eval/success/examples/example26.kriti
@@ -1,8 +1,9 @@
 {
     "array":
-        {{ toPairs
+        {{ toPairs(
             { "a" : "b",
               "c" : "d"
             }
+	    )
         }}
 }

--- a/test/data/eval/success/examples/example27.kriti
+++ b/test/data/eval/success/examples/example27.kriti
@@ -1,13 +1,13 @@
 {
     "array1":
-        {{ concat [
+        {{ concat([
           [1,2],
           [3,4]
-        ] }},
+        ]) }},
     "array2":
-        {{ concat [
+        {{ concat([
           "hello",
           " ",
           "world"
-        ] }}
+        ]) }}
 }

--- a/test/data/parser/success/examples/customFunctions.kriti
+++ b/test/data/parser/success/examples/customFunctions.kriti
@@ -1,9 +1,9 @@
 # function calls
-[ {{ head "foo" }},
-  {{ not (empty (tail "f")) }},
-  {{ size $path[0] }},
-  {{ inverse [1,2,3,4,5,6,7,8,9] }},
-  {{ toUpper "hello world"}},
-  {{ toTitle "hELLO wORLD"}},
-  {{ toLower "HELLO WORLD"}}
+[ {{ head("foo") }},
+  {{ not (empty(tail("f"))) }},
+  {{ size($path[0]) }},
+  {{ inverse([1,2,3,4,5,6,7,8,9]) }},
+  {{ toUpper("hello world")}},
+  {{ toTitle("hELLO wORLD")}},
+  {{ toLower("HELLO WORLD")}}
 ]

--- a/test/data/parser/success/examples/functions.kriti
+++ b/test/data/parser/success/examples/functions.kriti
@@ -1,7 +1,7 @@
 # function calls
-[ {{ escapeUri "foo" }},
-  {{ escapeUri "foo{{$bar}}" }},
-  {{ escapeUri $path[0] }},
-  {{ escapeUri "?foo=bar/baz" }},
-  "http://www.google.com{{escapeUri $params}}"
+[ {{ escapeUri("foo") }},
+  {{ escapeUri("foo{{$bar}}") }},
+  {{ escapeUri($path[0]) }},
+  {{ escapeUri("?foo=bar/baz") }},
+  "http://www.google.com{{escapeUri($params)}}"
 ]

--- a/test/data/parser/success/examples/operators.kriti
+++ b/test/data/parser/success/examples/operators.kriti
@@ -4,11 +4,11 @@
   {{ $foo == 1 }},
   {{ $foo <= 1 }},
   {{ $foo ?? 1 }},
-  {{ $foo != (not $bar) }},
-  {{ $foo || (not true) }},
-  {{ $foo && (not true) }},
+  {{ $foo != (not($bar)) }},
+  {{ $foo || (not(true)) }},
+  {{ $foo && (not(true)) }},
   {{ $foo in {"foo": 1} }},
   {{ $foo in {"foo": {{ $bar }} } }},
-  {{ not true && false }},
-  {{ not true ?? false }}
+  {{ not(true) && false }},
+  {{ not(true) ?? false }}
 ]

--- a/test/data/parser/success/golden/customFunctions.txt
+++ b/test/data/parser/success/golden/customFunctions.txt
@@ -18,7 +18,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 1
-                , col = 10
+                , col = 17
                 }
             }
         ) "head"
@@ -56,7 +56,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 2
-                , col = 9
+                , col = 27
                 }
             }
         ) "not"
@@ -68,7 +68,7 @@ Array
                     }
                 , end = AlexSourcePos
                     { line = 2
-                    , col = 16
+                    , col = 27
                     }
                 }
             ) "empty"
@@ -76,11 +76,11 @@ Array
                 ( Span
                     { start = AlexSourcePos
                         { line = 2
-                        , col = 18
+                        , col = 17
                         }
                     , end = AlexSourcePos
                         { line = 2
-                        , col = 22
+                        , col = 26
                         }
                     }
                 ) "tail"
@@ -88,11 +88,11 @@ Array
                     ( Span
                         { start = AlexSourcePos
                             { line = 2
-                            , col = 23
+                            , col = 22
                             }
                         , end = AlexSourcePos
                             { line = 2
-                            , col = 26
+                            , col = 25
                             }
                         }
                     )
@@ -100,11 +100,11 @@ Array
                         ( Span
                             { start = AlexSourcePos
                                 { line = 2
-                                , col = 24
+                                , col = 23
                                 }
                             , end = AlexSourcePos
                                 { line = 2
-                                , col = 25
+                                , col = 24
                                 }
                             }
                         ) "f"
@@ -120,7 +120,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 3
-                , col = 10
+                , col = 20
                 }
             }
         ) "size"
@@ -170,7 +170,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 4
-                , col = 13
+                , col = 34
                 }
             }
         ) "inverse"
@@ -304,7 +304,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 5
-                , col = 13
+                , col = 28
                 }
             }
         ) "toUpper"
@@ -342,7 +342,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 6
-                , col = 13
+                , col = 28
                 }
             }
         ) "toTitle"
@@ -380,7 +380,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 7
-                , col = 13
+                , col = 28
                 }
             }
         ) "toLower"

--- a/test/data/parser/success/golden/functions.txt
+++ b/test/data/parser/success/golden/functions.txt
@@ -18,7 +18,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 1
-                , col = 15
+                , col = 22
                 }
             }
         ) "escapeUri"
@@ -56,7 +56,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 2
-                , col = 15
+                , col = 30
                 }
             }
         ) "escapeUri"
@@ -119,7 +119,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 3
-                , col = 15
+                , col = 25
                 }
             }
         ) "escapeUri"
@@ -169,7 +169,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 4
-                , col = 15
+                , col = 31
                 }
             }
         ) "escapeUri"
@@ -207,7 +207,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 5
-                , col = 47
+                , col = 48
                 }
             }
         )
@@ -231,7 +231,7 @@ Array
                     }
                 , end = AlexSourcePos
                     { line = 5
-                    , col = 36
+                    , col = 45
                     }
                 }
             ) "escapeUri"

--- a/test/data/parser/success/golden/operators.txt
+++ b/test/data/parser/success/golden/operators.txt
@@ -311,7 +311,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 6
-                , col = 18
+                , col = 23
                 }
             }
         )
@@ -349,7 +349,7 @@ Array
                     }
                 , end = AlexSourcePos
                     { line = 6
-                    , col = 18
+                    , col = 23
                     }
                 }
             ) "not"
@@ -388,7 +388,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 7
-                , col = 18
+                , col = 23
                 }
             }
         )
@@ -426,7 +426,7 @@ Array
                     }
                 , end = AlexSourcePos
                     { line = 7
-                    , col = 18
+                    , col = 23
                     }
                 }
             ) "not"
@@ -452,7 +452,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 8
-                , col = 18
+                , col = 23
                 }
             }
         )
@@ -490,7 +490,7 @@ Array
                     }
                 , end = AlexSourcePos
                     { line = 8
-                    , col = 18
+                    , col = 23
                     }
                 }
             ) "not"
@@ -667,7 +667,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 11
-                , col = 23
+                , col = 24
                 }
             }
         )
@@ -679,7 +679,7 @@ Array
                     }
                 , end = AlexSourcePos
                     { line = 11
-                    , col = 9
+                    , col = 14
                     }
                 }
             ) "not"
@@ -701,11 +701,11 @@ Array
             ( Span
                 { start = AlexSourcePos
                     { line = 11
-                    , col = 18
+                    , col = 19
                     }
                 , end = AlexSourcePos
                     { line = 11
-                    , col = 23
+                    , col = 24
                     }
                 }
             ) False
@@ -718,7 +718,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 12
-                , col = 23
+                , col = 24
                 }
             }
         )
@@ -730,7 +730,7 @@ Array
                     }
                 , end = AlexSourcePos
                     { line = 12
-                    , col = 9
+                    , col = 14
                     }
                 }
             ) "not"
@@ -752,11 +752,11 @@ Array
             ( Span
                 { start = AlexSourcePos
                     { line = 12
-                    , col = 18
+                    , col = 19
                     }
                 , end = AlexSourcePos
                     { line = 12
-                    , col = 23
+                    , col = 24
                     }
                 }
             ) False


### PR DESCRIPTION
We unofficially supported function application syntax with no parens. Given some other properties of our grammar this was a potential source of ambiguity. This PR requires parens for all function application with the execption of the `not` operator.