### PR TITLE
Allow arbitrary expressions as range iteratee

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Upcoming
 
+  - Allow arbitrary expressions as `range` iteratee.
   - Adds `Kriti.CustomFunctions.basicFuncMap` functions to the kriti executable.
   - Adds `KritiError` type to exports from `Kriti`.
   

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -20,7 +20,8 @@ expr
   | '{{' expr '}}'
 
 ap
-  : function
+  : ident '(' expr ')'
+  | 'not' expr
   | atom
 
 atom
@@ -49,10 +50,6 @@ path_element
   | '?' '[' '\'' string '\'' ']'
   | '[' int ']'
   | '?' '[' int ']'
-
-function
-  : ident '(' expr ')'
-  | 'not' expr
 
 range
   : '{{' 'range' mident ',' ident ':=' expr '}}' expr '{{' 'end' '}}'

--- a/grammar.bnf
+++ b/grammar.bnf
@@ -55,7 +55,7 @@ function
   | 'not' expr
 
 range
-  : '{{' 'range' mident ',' ident ':=' path_vector '}}' expr '{{' 'end' '}}'
+  : '{{' 'range' mident ',' ident ':=' expr '}}' expr '{{' 'end' '}}'
 
 mident
   : '_'

--- a/src/Kriti/Parser/Grammar.y
+++ b/src/Kriti/Parser/Grammar.y
@@ -143,7 +143,7 @@ path_element
 
 range :: { ValueExt }
 range
-  : '{{' 'range' mident ',' ident ':=' path_vector '}}' expr '{{' 'end' '}}' { Range (locate $1 <> locate $12) (fmap unLoc $3) (unLoc $5) (snd $7) $9 }
+  : '{{' 'range' mident ',' ident ':=' expr '}}' expr '{{' 'end' '}}' { Range (locate $1 <> locate $12) (fmap unLoc $3) (unLoc $5) $7 $9 }
 
 mident :: { Maybe (Loc T.Text) }
 mident

--- a/src/Kriti/Parser/Token.hs
+++ b/src/Kriti/Parser/Token.hs
@@ -151,7 +151,7 @@ data ValueExt
   | Or Span ValueExt ValueExt
   | In Span ValueExt ValueExt
   | Defaulting Span ValueExt ValueExt
-  | Range Span (Maybe T.Text) T.Text (V.Vector Accessor) ValueExt
+  | Range Span (Maybe T.Text) T.Text ValueExt ValueExt
   | Function Span T.Text ValueExt
   deriving (Show, Eq, Read, Generic)
 
@@ -221,7 +221,7 @@ instance Pretty ValueExt where
     Defaulting _ t1 t2 -> pretty t1 <+> "??" <+> pretty t2
     Range _ i bndr xs t1 ->
       vsep
-        [ "{{" <+> "range" <+> pretty i <> comma <+> pretty bndr <+> colon <> equals <+> foldMap pretty xs <+> "}}",
+        [ "{{" <+> "range" <+> pretty i <> comma <+> pretty bndr <+> colon <> equals <+> pretty xs <+> "}}",
           indent 2 $ pretty t1,
           "{{" <+> "end" <+> "}}"
         ]

--- a/test/data/eval/success/examples/example32.kriti
+++ b/test/data/eval/success/examples/example32.kriti
@@ -1,0 +1,8 @@
+
+[
+  {{ range _, x := {{ if true }} {{ $ }} {{ else }} [] {{ end }} }}
+    {{ range i, friend := x.friends }}
+      {"name": {{ friend.name }}}
+    {{ end }}
+  {{ end }}
+]

--- a/test/data/eval/success/golden/example32.json
+++ b/test/data/eval/success/golden/example32.json
@@ -1,0 +1,59 @@
+[
+    [
+        [
+            {
+                "name": "Wilkerson Gill"
+            },
+            {
+                "name": "Gonzalez Long"
+            },
+            {
+                "name": "Hanson Ellison"
+            }
+        ],
+        [
+            {
+                "name": "Shanna Emerson"
+            },
+            {
+                "name": "Charmaine Tate"
+            },
+            {
+                "name": "Elisa Albert"
+            }
+        ],
+        [
+            {
+                "name": "Ford Crosby"
+            },
+            {
+                "name": "Owens Vaughn"
+            },
+            {
+                "name": "Lesley Lopez"
+            }
+        ],
+        [
+            {
+                "name": "Megan Hahn"
+            },
+            {
+                "name": "Green Mathews"
+            },
+            {
+                "name": "Maddox Tucker"
+            }
+        ],
+        [
+            {
+                "name": "Patton Larson"
+            },
+            {
+                "name": "Casey Grimes"
+            },
+            {
+                "name": "Geneva Carroll"
+            }
+        ]
+    ]
+]

--- a/test/data/parser/success/examples/ranges.kriti
+++ b/test/data/parser/success/examples/ranges.kriti
@@ -5,5 +5,6 @@
     {"hello": {{$foo.bar }}}
     # Random Comment
   {{ end }},
+  [{{ range i, x := {{ if true }} $.events {{ else }} [] {{ end }} }} { "name": {{ x.name }} } {{ end }}],
   [{{ range i, x := $.events }} { "name": {{ x.name }} } {{ end }}]
 ]

--- a/test/data/parser/success/golden/ranges.txt
+++ b/test/data/parser/success/golden/ranges.txt
@@ -23,7 +23,7 @@ Array
             }
         )
         ( Just "i" ) "x"
-        [ Obj
+        ( Path
             ( Span
                 { start = AlexSourcePos
                     { line = 1
@@ -31,35 +31,48 @@ Array
                     }
                 , end = AlexSourcePos
                     { line = 1
-                    , col = 24
-                    }
-                }
-            ) NotOptional "$foo" Head
-        , Obj
-            ( Span
-                { start = AlexSourcePos
-                    { line = 1
-                    , col = 24
-                    }
-                , end = AlexSourcePos
-                    { line = 1
-                    , col = 28
-                    }
-                }
-            ) NotOptional "bar" DotAccess
-        , Arr
-            ( Span
-                { start = AlexSourcePos
-                    { line = 1
-                    , col = 28
-                    }
-                , end = AlexSourcePos
-                    { line = 1
                     , col = 31
                     }
                 }
-            ) NotOptional 0
-        ]
+            )
+            [ Obj
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 1
+                        , col = 20
+                        }
+                    , end = AlexSourcePos
+                        { line = 1
+                        , col = 24
+                        }
+                    }
+                ) NotOptional "$foo" Head
+            , Obj
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 1
+                        , col = 24
+                        }
+                    , end = AlexSourcePos
+                        { line = 1
+                        , col = 28
+                        }
+                    }
+                ) NotOptional "bar" DotAccess
+            , Arr
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 1
+                        , col = 28
+                        }
+                    , end = AlexSourcePos
+                        { line = 1
+                        , col = 31
+                        }
+                    }
+                ) NotOptional 0
+            ]
+        )
         ( Object
             ( Span
                 { start = AlexSourcePos
@@ -116,7 +129,7 @@ Array
                 }
             }
         ) Nothing "x"
-        [ Obj
+        ( Path
             ( Span
                 { start = AlexSourcePos
                     { line = 2
@@ -124,35 +137,48 @@ Array
                     }
                 , end = AlexSourcePos
                     { line = 2
-                    , col = 24
-                    }
-                }
-            ) NotOptional "$foo" Head
-        , Obj
-            ( Span
-                { start = AlexSourcePos
-                    { line = 2
-                    , col = 24
-                    }
-                , end = AlexSourcePos
-                    { line = 2
-                    , col = 28
-                    }
-                }
-            ) NotOptional "bar" DotAccess
-        , Arr
-            ( Span
-                { start = AlexSourcePos
-                    { line = 2
-                    , col = 28
-                    }
-                , end = AlexSourcePos
-                    { line = 2
                     , col = 31
                     }
                 }
-            ) NotOptional 0
-        ]
+            )
+            [ Obj
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 2
+                        , col = 20
+                        }
+                    , end = AlexSourcePos
+                        { line = 2
+                        , col = 24
+                        }
+                    }
+                ) NotOptional "$foo" Head
+            , Obj
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 2
+                        , col = 24
+                        }
+                    , end = AlexSourcePos
+                        { line = 2
+                        , col = 28
+                        }
+                    }
+                ) NotOptional "bar" DotAccess
+            , Arr
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 2
+                        , col = 28
+                        }
+                    , end = AlexSourcePos
+                        { line = 2
+                        , col = 31
+                        }
+                    }
+                ) NotOptional 0
+            ]
+        )
         ( Object
             ( Span
                 { start = AlexSourcePos
@@ -209,7 +235,7 @@ Array
                 }
             }
         ) Nothing "x"
-        [ Obj
+        ( Path
             ( Span
                 { start = AlexSourcePos
                     { line = 3
@@ -217,35 +243,48 @@ Array
                     }
                 , end = AlexSourcePos
                     { line = 3
-                    , col = 24
-                    }
-                }
-            ) NotOptional "$foo" Head
-        , Obj
-            ( Span
-                { start = AlexSourcePos
-                    { line = 3
-                    , col = 24
-                    }
-                , end = AlexSourcePos
-                    { line = 3
-                    , col = 28
-                    }
-                }
-            ) NotOptional "bar" DotAccess
-        , Arr
-            ( Span
-                { start = AlexSourcePos
-                    { line = 3
-                    , col = 28
-                    }
-                , end = AlexSourcePos
-                    { line = 3
                     , col = 31
                     }
                 }
-            ) NotOptional 0
-        ]
+            )
+            [ Obj
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 3
+                        , col = 20
+                        }
+                    , end = AlexSourcePos
+                        { line = 3
+                        , col = 24
+                        }
+                    }
+                ) NotOptional "$foo" Head
+            , Obj
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 3
+                        , col = 24
+                        }
+                    , end = AlexSourcePos
+                        { line = 3
+                        , col = 28
+                        }
+                    }
+                ) NotOptional "bar" DotAccess
+            , Arr
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 3
+                        , col = 28
+                        }
+                    , end = AlexSourcePos
+                        { line = 3
+                        , col = 31
+                        }
+                    }
+                ) NotOptional 0
+            ]
+        )
         ( Object
             ( Span
                 { start = AlexSourcePos
@@ -327,7 +366,7 @@ Array
                 }
             )
             ( Just "i" ) "x"
-            [ Obj
+            ( Path
                 ( Span
                     { start = AlexSourcePos
                         { line = 7
@@ -335,23 +374,36 @@ Array
                         }
                     , end = AlexSourcePos
                         { line = 7
-                        , col = 22
-                        }
-                    }
-                ) NotOptional "$" Head
-            , Obj
-                ( Span
-                    { start = AlexSourcePos
-                        { line = 7
-                        , col = 22
-                        }
-                    , end = AlexSourcePos
-                        { line = 7
                         , col = 29
                         }
                     }
-                ) NotOptional "events" DotAccess
-            ]
+                )
+                [ Obj
+                    ( Span
+                        { start = AlexSourcePos
+                            { line = 7
+                            , col = 21
+                            }
+                        , end = AlexSourcePos
+                            { line = 7
+                            , col = 22
+                            }
+                        }
+                    ) NotOptional "$" Head
+                , Obj
+                    ( Span
+                        { start = AlexSourcePos
+                            { line = 7
+                            , col = 22
+                            }
+                        , end = AlexSourcePos
+                            { line = 7
+                            , col = 29
+                            }
+                        }
+                    ) NotOptional "events" DotAccess
+                ]
+            )
             ( Object
                 ( Span
                     { start = AlexSourcePos

--- a/test/data/parser/success/golden/ranges.txt
+++ b/test/data/parser/success/golden/ranges.txt
@@ -5,7 +5,7 @@ Array
             , col = 1
             }
         , end = AlexSourcePos
-            { line = 8
+            { line = 9
             , col = 2
             }
         }
@@ -349,7 +349,7 @@ Array
                 }
             , end = AlexSourcePos
                 { line = 7
-                , col = 68
+                , col = 106
                 }
             }
         )
@@ -361,12 +361,12 @@ Array
                     }
                 , end = AlexSourcePos
                     { line = 7
-                    , col = 67
+                    , col = 105
                     }
                 }
             )
             ( Just "i" ) "x"
-            ( Path
+            ( Iff
                 ( Span
                     { start = AlexSourcePos
                         { line = 7
@@ -374,45 +374,84 @@ Array
                         }
                     , end = AlexSourcePos
                         { line = 7
-                        , col = 29
+                        , col = 67
                         }
                     }
                 )
-                [ Obj
+                ( Boolean
                     ( Span
                         { start = AlexSourcePos
                             { line = 7
-                            , col = 21
+                            , col = 27
                             }
                         , end = AlexSourcePos
                             { line = 7
-                            , col = 22
+                            , col = 31
                             }
                         }
-                    ) NotOptional "$" Head
-                , Obj
+                    ) True
+                )
+                ( Path
                     ( Span
                         { start = AlexSourcePos
                             { line = 7
-                            , col = 22
+                            , col = 35
                             }
                         , end = AlexSourcePos
                             { line = 7
-                            , col = 29
+                            , col = 43
                             }
                         }
-                    ) NotOptional "events" DotAccess
-                ]
+                    )
+                    [ Obj
+                        ( Span
+                            { start = AlexSourcePos
+                                { line = 7
+                                , col = 35
+                                }
+                            , end = AlexSourcePos
+                                { line = 7
+                                , col = 36
+                                }
+                            }
+                        ) NotOptional "$" Head
+                    , Obj
+                        ( Span
+                            { start = AlexSourcePos
+                                { line = 7
+                                , col = 36
+                                }
+                            , end = AlexSourcePos
+                                { line = 7
+                                , col = 43
+                                }
+                            }
+                        ) NotOptional "events" DotAccess
+                    ]
+                )
+                ( Array
+                    ( Span
+                        { start = AlexSourcePos
+                            { line = 7
+                            , col = 55
+                            }
+                        , end = AlexSourcePos
+                            { line = 7
+                            , col = 57
+                            }
+                        }
+                    ) []
+                )
             )
             ( Object
                 ( Span
                     { start = AlexSourcePos
                         { line = 7
-                        , col = 33
+                        , col = 71
                         }
                     , end = AlexSourcePos
                         { line = 7
-                        , col = 57
+                        , col = 95
                         }
                     }
                 )
@@ -423,11 +462,11 @@ Array
                             ( Span
                                 { start = AlexSourcePos
                                     { line = 7
-                                    , col = 46
+                                    , col = 84
                                     }
                                 , end = AlexSourcePos
                                     { line = 7
-                                    , col = 52
+                                    , col = 90
                                     }
                                 }
                             )
@@ -435,11 +474,11 @@ Array
                                 ( Span
                                     { start = AlexSourcePos
                                         { line = 7
-                                        , col = 46
+                                        , col = 84
                                         }
                                     , end = AlexSourcePos
                                         { line = 7
-                                        , col = 47
+                                        , col = 85
                                         }
                                     }
                                 ) NotOptional "x" Head
@@ -447,10 +486,130 @@ Array
                                 ( Span
                                     { start = AlexSourcePos
                                         { line = 7
-                                        , col = 47
+                                        , col = 85
                                         }
                                     , end = AlexSourcePos
                                         { line = 7
+                                        , col = 90
+                                        }
+                                    }
+                                ) NotOptional "name" DotAccess
+                            ]
+                        )
+                    ]
+                )
+            )
+        ]
+    , Array
+        ( Span
+            { start = AlexSourcePos
+                { line = 8
+                , col = 3
+                }
+            , end = AlexSourcePos
+                { line = 8
+                , col = 68
+                }
+            }
+        )
+        [ Range
+            ( Span
+                { start = AlexSourcePos
+                    { line = 8
+                    , col = 4
+                    }
+                , end = AlexSourcePos
+                    { line = 8
+                    , col = 67
+                    }
+                }
+            )
+            ( Just "i" ) "x"
+            ( Path
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 8
+                        , col = 21
+                        }
+                    , end = AlexSourcePos
+                        { line = 8
+                        , col = 29
+                        }
+                    }
+                )
+                [ Obj
+                    ( Span
+                        { start = AlexSourcePos
+                            { line = 8
+                            , col = 21
+                            }
+                        , end = AlexSourcePos
+                            { line = 8
+                            , col = 22
+                            }
+                        }
+                    ) NotOptional "$" Head
+                , Obj
+                    ( Span
+                        { start = AlexSourcePos
+                            { line = 8
+                            , col = 22
+                            }
+                        , end = AlexSourcePos
+                            { line = 8
+                            , col = 29
+                            }
+                        }
+                    ) NotOptional "events" DotAccess
+                ]
+            )
+            ( Object
+                ( Span
+                    { start = AlexSourcePos
+                        { line = 8
+                        , col = 33
+                        }
+                    , end = AlexSourcePos
+                        { line = 8
+                        , col = 57
+                        }
+                    }
+                )
+                ( fromList
+                    [
+                        ( "name"
+                        , Path
+                            ( Span
+                                { start = AlexSourcePos
+                                    { line = 8
+                                    , col = 46
+                                    }
+                                , end = AlexSourcePos
+                                    { line = 8
+                                    , col = 52
+                                    }
+                                }
+                            )
+                            [ Obj
+                                ( Span
+                                    { start = AlexSourcePos
+                                        { line = 8
+                                        , col = 46
+                                        }
+                                    , end = AlexSourcePos
+                                        { line = 8
+                                        , col = 47
+                                        }
+                                    }
+                                ) NotOptional "x" Head
+                            , Obj
+                                ( Span
+                                    { start = AlexSourcePos
+                                        { line = 8
+                                        , col = 47
+                                        }
+                                    , end = AlexSourcePos
+                                        { line = 8
                                         , col = 52
                                         }
                                     }

--- a/test/data/parser/success/golden/richExample1.txt
+++ b/test/data/parser/success/golden/richExample1.txt
@@ -129,7 +129,7 @@ Object
                                         }
                                     }
                                 ) Nothing "x"
-                                [ Obj
+                                ( Path
                                     ( Span
                                         { start = AlexSourcePos
                                             { line = 6
@@ -137,47 +137,60 @@ Object
                                             }
                                         , end = AlexSourcePos
                                             { line = 6
-                                            , col = 19
-                                            }
-                                        }
-                                    ) NotOptional "$" Head
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 6
-                                            , col = 19
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 6
-                                            , col = 25
-                                            }
-                                        }
-                                    ) NotOptional "event" DotAccess
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 6
-                                            , col = 25
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 6
-                                            , col = 32
-                                            }
-                                        }
-                                    ) NotOptional "author" DotAccess
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 6
-                                            , col = 32
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 6
                                             , col = 41
                                             }
                                         }
-                                    ) NotOptional "articles" DotAccess
-                                ]
+                                    )
+                                    [ Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 6
+                                                , col = 18
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 6
+                                                , col = 19
+                                                }
+                                            }
+                                        ) NotOptional "$" Head
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 6
+                                                , col = 19
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 6
+                                                , col = 25
+                                                }
+                                            }
+                                        ) NotOptional "event" DotAccess
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 6
+                                                , col = 25
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 6
+                                                , col = 32
+                                                }
+                                            }
+                                        ) NotOptional "author" DotAccess
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 6
+                                                , col = 32
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 6
+                                                , col = 41
+                                                }
+                                            }
+                                        ) NotOptional "articles" DotAccess
+                                    ]
+                                )
                                 ( Object
                                     ( Span
                                         { start = AlexSourcePos
@@ -286,7 +299,7 @@ Object
                                         }
                                     }
                                 ) Nothing "x"
-                                [ Obj
+                                ( Path
                                     ( Span
                                         { start = AlexSourcePos
                                             { line = 13
@@ -294,47 +307,60 @@ Object
                                             }
                                         , end = AlexSourcePos
                                             { line = 13
-                                            , col = 19
-                                            }
-                                        }
-                                    ) NotOptional "$" Head
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 13
-                                            , col = 19
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 13
-                                            , col = 25
-                                            }
-                                        }
-                                    ) NotOptional "event" DotAccess
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 13
-                                            , col = 25
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 13
-                                            , col = 32
-                                            }
-                                        }
-                                    ) NotOptional "author" DotAccess
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 13
-                                            , col = 32
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 13
                                             , col = 41
                                             }
                                         }
-                                    ) NotOptional "articles" DotAccess
-                                ]
+                                    )
+                                    [ Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 13
+                                                , col = 18
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 13
+                                                , col = 19
+                                                }
+                                            }
+                                        ) NotOptional "$" Head
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 13
+                                                , col = 19
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 13
+                                                , col = 25
+                                                }
+                                            }
+                                        ) NotOptional "event" DotAccess
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 13
+                                                , col = 25
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 13
+                                                , col = 32
+                                                }
+                                            }
+                                        ) NotOptional "author" DotAccess
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 13
+                                                , col = 32
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 13
+                                                , col = 41
+                                                }
+                                            }
+                                        ) NotOptional "articles" DotAccess
+                                    ]
+                                )
                                 ( Object
                                     ( Span
                                         { start = AlexSourcePos

--- a/test/data/parser/success/golden/richExample2.txt
+++ b/test/data/parser/success/golden/richExample2.txt
@@ -129,7 +129,7 @@ Object
                                         }
                                     }
                                 ) Nothing "x"
-                                [ Obj
+                                ( Path
                                     ( Span
                                         { start = AlexSourcePos
                                             { line = 6
@@ -137,47 +137,60 @@ Object
                                             }
                                         , end = AlexSourcePos
                                             { line = 6
-                                            , col = 19
-                                            }
-                                        }
-                                    ) NotOptional "$" Head
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 6
-                                            , col = 19
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 6
-                                            , col = 25
-                                            }
-                                        }
-                                    ) NotOptional "event" DotAccess
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 6
-                                            , col = 25
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 6
-                                            , col = 32
-                                            }
-                                        }
-                                    ) NotOptional "author" DotAccess
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 6
-                                            , col = 32
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 6
                                             , col = 41
                                             }
                                         }
-                                    ) NotOptional "articles" DotAccess
-                                ]
+                                    )
+                                    [ Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 6
+                                                , col = 18
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 6
+                                                , col = 19
+                                                }
+                                            }
+                                        ) NotOptional "$" Head
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 6
+                                                , col = 19
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 6
+                                                , col = 25
+                                                }
+                                            }
+                                        ) NotOptional "event" DotAccess
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 6
+                                                , col = 25
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 6
+                                                , col = 32
+                                                }
+                                            }
+                                        ) NotOptional "author" DotAccess
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 6
+                                                , col = 32
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 6
+                                                , col = 41
+                                                }
+                                            }
+                                        ) NotOptional "articles" DotAccess
+                                    ]
+                                )
                                 ( Object
                                     ( Span
                                         { start = AlexSourcePos

--- a/test/data/parser/success/golden/richExample3.txt
+++ b/test/data/parser/success/golden/richExample3.txt
@@ -104,7 +104,7 @@ Object
                                         }
                                     }
                                 ) Nothing "x"
-                                [ Obj
+                                ( Path
                                     ( Span
                                         { start = AlexSourcePos
                                             { line = 5
@@ -112,47 +112,60 @@ Object
                                             }
                                         , end = AlexSourcePos
                                             { line = 5
-                                            , col = 19
-                                            }
-                                        }
-                                    ) NotOptional "$" Head
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 5
-                                            , col = 19
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 5
-                                            , col = 25
-                                            }
-                                        }
-                                    ) NotOptional "event" DotAccess
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 5
-                                            , col = 25
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 5
-                                            , col = 32
-                                            }
-                                        }
-                                    ) NotOptional "author" DotAccess
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 5
-                                            , col = 32
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 5
                                             , col = 41
                                             }
                                         }
-                                    ) NotOptional "articles" DotAccess
-                                ]
+                                    )
+                                    [ Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 5
+                                                , col = 18
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 5
+                                                , col = 19
+                                                }
+                                            }
+                                        ) NotOptional "$" Head
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 5
+                                                , col = 19
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 5
+                                                , col = 25
+                                                }
+                                            }
+                                        ) NotOptional "event" DotAccess
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 5
+                                                , col = 25
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 5
+                                                , col = 32
+                                                }
+                                            }
+                                        ) NotOptional "author" DotAccess
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 5
+                                                , col = 32
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 5
+                                                , col = 41
+                                                }
+                                            }
+                                        ) NotOptional "articles" DotAccess
+                                    ]
+                                )
                                 ( Iff
                                     ( Span
                                         { start = AlexSourcePos

--- a/test/data/parser/success/golden/richExample4.txt
+++ b/test/data/parser/success/golden/richExample4.txt
@@ -104,7 +104,7 @@ Object
                                         }
                                     }
                                 ) Nothing "x"
-                                [ Obj
+                                ( Path
                                     ( Span
                                         { start = AlexSourcePos
                                             { line = 5
@@ -112,47 +112,60 @@ Object
                                             }
                                         , end = AlexSourcePos
                                             { line = 5
-                                            , col = 19
-                                            }
-                                        }
-                                    ) NotOptional "$" Head
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 5
-                                            , col = 19
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 5
-                                            , col = 25
-                                            }
-                                        }
-                                    ) NotOptional "event" DotAccess
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 5
-                                            , col = 25
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 5
-                                            , col = 32
-                                            }
-                                        }
-                                    ) NotOptional "author" DotAccess
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 5
-                                            , col = 32
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 5
                                             , col = 41
                                             }
                                         }
-                                    ) NotOptional "articles" DotAccess
-                                ]
+                                    )
+                                    [ Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 5
+                                                , col = 18
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 5
+                                                , col = 19
+                                                }
+                                            }
+                                        ) NotOptional "$" Head
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 5
+                                                , col = 19
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 5
+                                                , col = 25
+                                                }
+                                            }
+                                        ) NotOptional "event" DotAccess
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 5
+                                                , col = 25
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 5
+                                                , col = 32
+                                                }
+                                            }
+                                        ) NotOptional "author" DotAccess
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 5
+                                                , col = 32
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 5
+                                                , col = 41
+                                                }
+                                            }
+                                        ) NotOptional "articles" DotAccess
+                                    ]
+                                )
                                 ( Object
                                     ( Span
                                         { start = AlexSourcePos

--- a/test/data/parser/success/golden/richExample5.txt
+++ b/test/data/parser/success/golden/richExample5.txt
@@ -104,7 +104,7 @@ Object
                                         }
                                     }
                                 ) Nothing "x"
-                                [ Obj
+                                ( Path
                                     ( Span
                                         { start = AlexSourcePos
                                             { line = 5
@@ -112,47 +112,60 @@ Object
                                             }
                                         , end = AlexSourcePos
                                             { line = 5
-                                            , col = 19
-                                            }
-                                        }
-                                    ) NotOptional "$" Head
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 5
-                                            , col = 19
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 5
-                                            , col = 25
-                                            }
-                                        }
-                                    ) NotOptional "event" DotAccess
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 5
-                                            , col = 25
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 5
-                                            , col = 32
-                                            }
-                                        }
-                                    ) NotOptional "author" DotAccess
-                                , Obj
-                                    ( Span
-                                        { start = AlexSourcePos
-                                            { line = 5
-                                            , col = 32
-                                            }
-                                        , end = AlexSourcePos
-                                            { line = 5
                                             , col = 41
                                             }
                                         }
-                                    ) NotOptional "articles" DotAccess
-                                ]
+                                    )
+                                    [ Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 5
+                                                , col = 18
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 5
+                                                , col = 19
+                                                }
+                                            }
+                                        ) NotOptional "$" Head
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 5
+                                                , col = 19
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 5
+                                                , col = 25
+                                                }
+                                            }
+                                        ) NotOptional "event" DotAccess
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 5
+                                                , col = 25
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 5
+                                                , col = 32
+                                                }
+                                            }
+                                        ) NotOptional "author" DotAccess
+                                    , Obj
+                                        ( Span
+                                            { start = AlexSourcePos
+                                                { line = 5
+                                                , col = 32
+                                                }
+                                            , end = AlexSourcePos
+                                                { line = 5
+                                                , col = 41
+                                                }
+                                            }
+                                        ) NotOptional "articles" DotAccess
+                                    ]
+                                )
                                 ( Object
                                     ( Span
                                         { start = AlexSourcePos


### PR DESCRIPTION
When declaraing the iteratee for `range` statement, we required that it was a `Path` which evaluated to to an array. We now allow arbitrary expressions. They still must evaluate to an array, but they don't have to be a `Path` now.

resolves #66 