### PR TITLE
Version bump to 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Revision history for Kriti-Lang
 
 ## Upcoming
+  
+## 0.3.3 -- 2022-10-18
 
+  - Adds `elif` syntax to `if` expressions.
   - Improved error messaging and error codes.
   - Allow arbitrary expressions as `range` iteratee.
   - Adds `Kriti.CustomFunctions.basicFuncMap` functions to the kriti executable.

--- a/kriti-lang.cabal
+++ b/kriti-lang.cabal
@@ -1,6 +1,6 @@
 cabal-version:       3.0
 name:                kriti-lang
-version:             0.3.2
+version:             0.3.3
 copyright:           2021 Hasura Systems Private Limited
 author:              Solomon Bothwell
 maintainer:          solomon@hasura.io


### PR DESCRIPTION
## 0.3.3 -- 2022-10-18

  - Adds `elif` syntax to `if` expressions.
  - Improved error messaging and error codes.
  - Allow arbitrary expressions as `range` iteratee.
  - Adds `Kriti.CustomFunctions.basicFuncMap` functions to the kriti executable.
  - Adds `KritiError` type to exports from `Kriti`.
 